### PR TITLE
Add configurable redirect-url

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -127,6 +127,12 @@ class Client extends OpenIDConnectClient {
 
 	public function authenticate() {
 		$redirectUrl = $this->generator->linkToRouteAbsolute('openidconnect.loginFlow.login');
+
+		$openIdConfig = $this->getOpenIdConfig();
+		if (isset($openIdConfig['redirect-url'])) {
+			$redirectUrl = $openIdConfig['redirect-url'];
+		}
+
 		$this->setRedirectURL($redirectUrl);
 		return parent::authenticate();
 	}

--- a/lib/Controller/LoginFlowController.php
+++ b/lib/Controller/LoginFlowController.php
@@ -25,6 +25,7 @@ use OC\HintException;
 use OC\User\LoginException;
 use OC\User\Session;
 use OCA\OpenIdConnect\Client;
+use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\Response;
@@ -35,7 +36,7 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Util;
 
-class LoginFlowController extends \OCP\AppFramework\Controller {
+class LoginFlowController extends Controller {
 
 	/**
 	 * @var ISession
@@ -89,8 +90,8 @@ class LoginFlowController extends \OCP\AppFramework\Controller {
 		if (!$openid) {
 			return new JSONResponse([]);
 		}
-		$wellKonwData = $openid->getWellKnownConfig();
-		return new JSONResponse($wellKonwData);
+		$wellKnownData = $openid->getWellKnownConfig();
+		return new JSONResponse($wellKnownData);
 	}
 
 	/**


### PR DESCRIPTION
## Description
This allows the redirect url - usually index.php/app/openidconnect/redirect - to be specified in the config.
In certain environments this is helpful to deploy the system more easily

## Motivation and Context
Changing config is faster then reconfiguring an OpenId Provider setup (big companies, processes....)

## How Has This Been Tested?
- will be done on the customer site

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
