### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,4 +109,13 @@ To set it up locally do the following:
     ```
 8. Clients can now use http://localhost:3000/.well-known/openid-configuration to obtain all information which is necessary
 to initiate the OpenId Connect flow. Use the granted access token in any request to ownCloud within a bearer authentication header.
-9. You can login with any credentials but you need to make sure that the user with the given user id exists. In a real world deployment the users will come from LDAP.
+9. You can login with any credentials but you need to make sure that the user with the given user id exists. In a real world deployment the users will come from LDAP.  
+Keep in mind that by default, oidc app will search for the `email` attribute - which is hardcoded to `johndoe@example.com` [ref](https://github.com/panva/node-oidc-provider/blob/master/example/support/account.js#L32)
+If you wish to map the login name on the oidc-provider with owncloud user ids, you can configure it as following:
+```
+    $CONFIG = [
+      'openid-connect' => [
+        'search-attribute' => 'sub',
+        'mode' => 'userid',
+      ]
+```


### PR DESCRIPTION
Improve the README to:
- reflect to use the latest configuration for a working setup for `panva/node-oidc-provider`
- reflect that by default we search for email - and if one wants to map oidc logins with owncloud usersids the configuration needs to be changed