### PR TITLE
Run acceptance tests against latest core release by default

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -621,7 +621,7 @@ def acceptance():
 	errorFound = False
 
 	default = {
-		'servers': ['daily-master-qa', '10.2.1'],
+		'servers': ['daily-master-qa', 'latest'],
 		'browsers': ['chrome'],
 		'phpVersions': ['7.0'],
 		'databases': ['mariadb:10.2'],


### PR DESCRIPTION
This change does not effect the actual test matrix here. It just gets the starlark code up-to-date so that if there are acceptance tests one day, they will get run with the correct defaults.