### PR TITLE
Add capability to connect phoenix with this OpenIdConnect setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,6 @@ PHPSTAN=php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan
 
 KARMA=$(NODE_PREFIX)/node_modules/.bin/karma
 
-nodejs_deps=node_modules
-
 .DEFAULT_GOAL := all
 
 help:
@@ -111,10 +109,6 @@ install-php-deps: vendor vendor-bin composer.json composer.lock
 .PHONY: install-js-deps
 install-js-deps: ## Install PHP dependencies
 install-js-deps: $(nodejs_deps)
-
-$(nodejs_deps): package.json yarn.lock
-	yarn install
-	touch $@
 
 vendor: composer.lock
 	$(COMPOSER_BIN) install --no-dev

--- a/tests/docker/README.md
+++ b/tests/docker/README.md
@@ -7,9 +7,32 @@ For Linux based system use `ip` (i.e. `ip addr add 10.254.254.254/32 dev lo`)
 - php / composer installed in order to execute the `Makefile`
 
 ## Get started
-- Issue `make install-deps` to have relevant dependecies for opendiconnect installed
+- Issue `make install-deps` to have relevant dependencies for opendiconnect installed
 - In the root folder of `openidconnect` the following commands to:
   - start `docker-compose -f tests/docker/docker-compose.yml up`
   - stop `docker-compose -f tests/docker/docker-compose.yml down -v`
 
-- owncloud is running at [http://10.254.254.254:8080](http://10.254.254.254:8080)
+- ownCloud is running at [http://10.254.254.254:8080](http://10.254.254.254:8080)
+
+## Connecting a phoenix instance
+- A locally running Phoenix instance can connect to this setup with following config.json.
+It is required that phoenix is running on port 8300 - follow the [build instructions](https://github.com/owncloud/phoenix#building-phoenix) 
+on how to get Phoenix started locally.
+
+```json
+{
+  "server": "http://10.254.254.254:8080",
+  "theme": "owncloud",
+  "version": "0.1.0",
+  "openIdConnect": {
+    "authority": "http://10.254.254.254:8080",
+    "metadataUrl": "http://10.254.254.254:8080/.well-known/openid-configuration",
+    "client_id": "phoenix",
+    "response_type": "code",
+    "scope": "openid profile email"
+  },
+  "apps" : [
+    "files", "pdf-viewer", "markdown-editor"
+  ]
+}
+```

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - ../../:/mnt/data/apps/openidconnect
       - ./owncloud/openid-connect.sh:/etc/pre_server.d/openid-connect.sh
       - ./owncloud/oidc.config.php:/mnt/data/config/oidc.config.php
+      - ./owncloud/phoenix.config.php:/mnt/data/config/phoenix.config.php
       - files:/mnt/data
 
   db:

--- a/tests/docker/node-oidc/configuration.js
+++ b/tests/docker/node-oidc/configuration.js
@@ -25,8 +25,15 @@ module.exports = Object.assign({
       client_secret: 'KFeFWWEZO9TkisIQzR3fo7hfiMXlOpaqP8CFuTbSHzV1TUuGECglPxpiVKJfOXIx',
       grant_types: ['refresh_token', 'authorization_code'],
       redirect_uris: ['oc.ios://ios.owncloud.com']
-    }
-  ],
+    },
+    {
+	  client_id: 'phoenix',
+	  client_secret: 'phoenix-rocks!',
+  	  grant_types: ['refresh_token', 'authorization_code'],
+      redirect_uris: ['http://10.254.254.254:8300/oidc-callback.html'],
+	  token_endpoint_auth_method: 'none'
+  }
+],
   cookies: {
     long: { signed: true, maxAge: (1 * 24 * 60 * 60) * 1000 }, // 1 day in ms
     short: { signed: true },

--- a/tests/docker/owncloud/phoenix.config.php
+++ b/tests/docker/owncloud/phoenix.config.php
@@ -1,0 +1,5 @@
+<?php
+$CONFIG = [
+	'cors.allowed-domains' => ['http://10.254.254.254:8300'],
+	'dav.enable.tech_preview' => true
+];


### PR DESCRIPTION
## Description
Now it is possible to use this docker compose setup with phoenix as well

## Related Issue
- refs https://github.com/owncloud/phoenix/issues/2020

## How Has This Been Tested?
- see tests/docker/README.md

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
