### PR TITLE
return null when token expired

### DIFF
--- a/lib/OpenIdConnectAuthModule.php
+++ b/lib/OpenIdConnectAuthModule.php
@@ -115,7 +115,7 @@ class OpenIdConnectAuthModule implements IAuthModule {
 				return $user;
 			}
 			return null;
-		} catch (OpenIDConnectClientException $ex) {
+		} catch (OpenIDConnectClientException | LoginException $ex) {
 			$this->logger->logException($ex);
 			return null;
 		}


### PR DESCRIPTION
the LoginException is not a OpenIDConnectClientException. This PR catches it, logs it and returns null as for other OpenID exceptions.

fixes https://github.com/owncloud/openidconnect/issues/86
