### PR TITLE
In case the id_token is provided we no longer need to call the user i…

### DIFF
--- a/lib/Controller/LoginFlowController.php
+++ b/lib/Controller/LoginFlowController.php
@@ -128,7 +128,12 @@ class LoginFlowController extends Controller {
 		}
 		$this->logger->debug('Access token: ' . $openid->getAccessToken());
 		$this->logger->debug('Refresh token: ' . $openid->getRefreshToken());
-		$userInfo = $openid->requestUserInfo();
+		$this->logger->debug('Id token: ' . $openid->getIdToken());
+		if ($openid->getIdToken()) {
+			$userInfo = $openid->getIdTokenPayload();
+		} else {
+			$userInfo = $openid->requestUserInfo();
+		}
 		$this->logger->debug('User info: ' . \json_encode($userInfo));
 		if (!$userInfo) {
 			throw new LoginException('No user information available.');

--- a/lib/OpenIdConnectAuthModule.php
+++ b/lib/OpenIdConnectAuthModule.php
@@ -185,7 +185,12 @@ class OpenIdConnectAuthModule implements IAuthModule {
 
 		$this->client->setAccessToken($bearerToken);
 
-		$userInfo = $this->client->requestUserInfo();
+		if ($this->client->getIdToken()) {
+			$userInfo = $this->client->getIdTokenPayload();
+		} else {
+			$userInfo = $this->client->requestUserInfo();
+		}
+
 		$this->logger->debug('User info: ' . \json_encode($userInfo));
 		if ($userInfo === null) {
 			return null;


### PR DESCRIPTION
## Description
In case the id_token is provided we no longer need to call the user info endpoint.
(On Azure AD the user info endpoint is hosted on a different domain and the access token cannot be used :vomit:)

## Related Issue
- refs https://github.com/owncloud/enterprise/issues/4197

## How Has This Been Tested?
- :hand: 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
