### PR TITLE
Limit OpenID Connect logins to users of specific user backend

### DIFF
--- a/tests/unit/Service/UserLookupServiceTest.php
+++ b/tests/unit/Service/UserLookupServiceTest.php
@@ -98,4 +98,23 @@ class UserLookupServiceTest extends TestCase {
 		$return = $this->userLookup->lookupUser((object)['preferred_username' => 'alice']);
 		self::assertEquals($user, $return);
 	}
+
+	public function testInvalidUserBackEnd(): void {
+		$this->client->method('getOpenIdConfig')->willReturn(['mode' => 'userid', 'search-attribute' => 'preferred_username', 'allowed-user-backends' => ['LDAP']]);
+		$user = $this->createMock(IUser::class);
+		$user->method('getBackendClassName')->willReturn('Database');
+		$this->manager->method('get')->willReturn($user);
+
+		$this->expectException(LoginException::class);
+		$this->userLookup->lookupUser((object)['preferred_username' => 'alice']);
+	}
+
+	public function testValidUserBackEnd(): void {
+		$this->client->method('getOpenIdConfig')->willReturn(['mode' => 'userid', 'search-attribute' => 'preferred_username', 'allowed-user-backends' => ['LDAP']]);
+		$user = $this->createMock(IUser::class);
+		$user->method('getBackendClassName')->willReturn('LDAP');
+		$this->manager->method('get')->willReturn($user);
+		$return = $this->userLookup->lookupUser((object)['preferred_username' => 'alice']);
+		self::assertEquals($user, $return);
+	}
 }


### PR DESCRIPTION
## Description
This adds a config option to limit users which are logged in via OpenID Connect to specific user backends - e.g. LDAP

Config.php:
```php
<?php
$CONFIG = [
	'openid-connect' => [
		'allowed-user-backends' => ['LDAP']
```

## Motivation and Context
In more security aware environments this can be of interest ..... :see_no_evil: 

## How Has This Been Tested?
- :hand: 

## Screenshots (if appropriate):
![Screenshot from 2020-09-15 13-11-20](https://user-images.githubusercontent.com/1005065/93203784-42031300-f755-11ea-8f7d-e861b37546d8.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
