### PR TITLE
Preserve redirect to oauth2 app on oidc login

### DIFF
--- a/lib/LoginPageBehaviour.php
+++ b/lib/LoginPageBehaviour.php
@@ -86,9 +86,14 @@ class LoginPageBehaviour {
 	 * @codeCoverageIgnore
 	 */
 	public function registerAlternativeLogin(string $loginName): void {
+		$buttonHref = $this->urlGenerator->linkToRoute('openidconnect.loginFlow.login');
+		$redirectUrl = $this->request->getParam('redirect_url');
+		if ($redirectUrl !== null) {
+			$buttonHref .= '?redirect_url=' . $redirectUrl;
+		}
 		OC_App::registerLogIn([
 			'name' => $loginName,
-			'href' => $this->urlGenerator->linkToRoute('openidconnect.loginFlow.login'),
+			'href' => $buttonHref,
 		]);
 	}
 }


### PR DESCRIPTION
## Description
When the request comes from oauth2 app we should keep the redirect url before login and restore afterwards

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4214

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

