### PR TITLE
Azure AD: Use access token payload instead of user info endpoint

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -99,6 +99,15 @@ class Client extends OpenIDConnectClient {
 		return $this->wellKnownConfig;
 	}
 
+	public function getUserInfo() {
+		$openIdConfig = $this->getOpenIdConfig();
+		if (isset($openIdConfig['use-access-token-payload-for-user-info']) && $openIdConfig['use-access-token-payload-for-user-info']) {
+			return $this->getAccessTokenPayload();
+		}
+
+		return $this->requestUserInfo();
+	}
+
 	/**
 	 * @codeCoverageIgnore
 	 */

--- a/lib/Controller/LoginFlowController.php
+++ b/lib/Controller/LoginFlowController.php
@@ -126,9 +126,15 @@ class LoginFlowController extends Controller {
 			$this->logger->logException($ex);
 			throw new HintException('Error in OpenIdConnect:' . $ex->getMessage());
 		}
-		$this->logger->debug('Access token: ' . $openid->getAccessToken());
-		$this->logger->debug('Refresh token: ' . $openid->getRefreshToken());
-		$userInfo = $openid->requestUserInfo();
+		$debugInfo = \json_encode([
+			'access_token' => $openid->getAccessToken(),
+			'refresh_token' => $openid->getRefreshToken(),
+			'id_token' => $openid->getIdToken(),
+			'access_token_payload' => $openid->getAccessTokenPayload(),
+		], JSON_PRETTY_PRINT);
+		$this->logger->debug('LoginFlowController::login : Token info: ' . $debugInfo);
+
+		$userInfo = $openid->getUserInfo();
 		$this->logger->debug('User info: ' . \json_encode($userInfo));
 		if (!$userInfo) {
 			throw new LoginException('No user information available.');

--- a/lib/Service/UserLookupService.php
+++ b/lib/Service/UserLookupService.php
@@ -60,6 +60,9 @@ class UserLookupService {
 			$searchByEmail = false;
 		}
 		$attribute = $openIdConfig['search-attribute'] ?? 'email';
+		if (!\property_exists($userInfo, $attribute)) {
+			throw new LoginException("Configured attribute $attribute is not known.");
+		}
 
 		if ($searchByEmail) {
 			$user = $this->userManager->getByEmail($userInfo->$attribute);

--- a/tests/unit/Controller/LoginFlowControllerLoginTest.php
+++ b/tests/unit/Controller/LoginFlowControllerLoginTest.php
@@ -117,7 +117,7 @@ class LoginFlowControllerLoginTest extends TestCase {
 
 	public function testLoginUnknownUser(): void {
 		$this->client->method('getOpenIdConfig')->willReturn([]);
-		$this->client->method('requestUserInfo')->willReturn((object)['email' => 'foo@exmaple.net']);
+		$this->client->method('getUserInfo')->willReturn((object)['email' => 'foo@exmaple.net']);
 		$this->userLookup->method('lookupUser')->willThrowException(new LoginException('User foo is not known.'));
 		$this->expectException(LoginException::class);
 		$this->expectExceptionMessage('User foo is not known.');
@@ -127,7 +127,7 @@ class LoginFlowControllerLoginTest extends TestCase {
 
 	public function testLoginCreateSessionFailed(): void {
 		$this->client->method('getOpenIdConfig')->willReturn([]);
-		$this->client->method('requestUserInfo')->willReturn((object)['email' => 'foo@exmaple.net']);
+		$this->client->method('getUserInfo')->willReturn((object)['email' => 'foo@exmaple.net']);
 		$user = $this->createMock(IUser::class);
 		$this->userLookup->method('lookupUser')->willReturn($user);
 		$this->userSession->method('createSessionToken')->willReturn(false);
@@ -138,7 +138,7 @@ class LoginFlowControllerLoginTest extends TestCase {
 
 	public function testLoginCreateSuccess(): void {
 		$this->client->method('getOpenIdConfig')->willReturn([]);
-		$this->client->method('requestUserInfo')->willReturn((object)['email' => 'foo@exmaple.net']);
+		$this->client->method('getUserInfo')->willReturn((object)['email' => 'foo@exmaple.net']);
 		$this->client->method('getIdToken')->willReturn('id');
 		$this->client->method('getAccessToken')->willReturn('access');
 		$this->client->method('getRefreshToken')->willReturn('refresh');

--- a/tests/unit/OpenIdConnectAuthModuleTest.php
+++ b/tests/unit/OpenIdConnectAuthModuleTest.php
@@ -126,7 +126,7 @@ class OpenIdConnectAuthModuleTest extends TestCase {
 	public function testValidTokenWithIntrospection(): void {
 		$this->client->method('getOpenIdConfig')->willReturn(['use-token-introspection-endpoint' => true]);
 		$this->client->method('introspectToken')->willReturn((object)['active' => true, 'exp' => \time() + 3600]);
-		$this->client->method('requestUserInfo')->willReturn((object)['email' => 'foo@example.com']);
+		$this->client->method('getUserInfo')->willReturn((object)['email' => 'foo@example.com']);
 		$this->cacheFactory->method('create')->willReturn(new ArrayCache());
 		$user = $this->createMock(IUser::class);
 		$this->lookupService->expects(self::once())->method('lookupUser')->willReturn($user);
@@ -141,7 +141,7 @@ class OpenIdConnectAuthModuleTest extends TestCase {
 		$this->client->method('getOpenIdConfig')->willReturn(['use-token-introspection-endpoint' => false]);
 		$this->client->method('verifyJWTsignature')->willReturn(true);
 		$this->client->method('getAccessTokenPayload')->willReturn((object)['exp' => \time() + 3600]);
-		$this->client->method('requestUserInfo')->willReturn((object)['email' => 'foo@example.com']);
+		$this->client->method('getUserInfo')->willReturn((object)['email' => 'foo@example.com']);
 		$this->cacheFactory->method('create')->willReturn(new ArrayCache());
 		$user = $this->createMock(IUser::class);
 		$this->lookupService->expects(self::once())->method('lookupUser')->willReturn($user);


### PR DESCRIPTION
## Description
On Azure AD we cannot use the user info endpoint due to it's limitation see https://medium.com/@abhinavsonkar/hi-thomas-53775651f0e5 and any linked information

MS suggests to use the id token - but the owncloud server as a rely party does not have the id token - only the access token.
The access token is a jwt token and holds some information which we can reuse to identify the user - e.g. preferred_username.

## How Has This Been Tested?
- setup owncloud and openid connect with azure ad (long story ...)
- log into owncloud in the browser and see this working
- steal the access token from debug logs
-  curl https://openid.owncloud-demo.com/ocs/v2.php/cloud/user -H "Authorization: Bearer $TOKEN"


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
