### PR TITLE
Fixes #86 and #106 - properly handle token expiry in the sabre dav au…

### DIFF
--- a/lib/Sabre/OpenIdSabreAuthBackend.php
+++ b/lib/Sabre/OpenIdSabreAuthBackend.php
@@ -110,18 +110,23 @@ class OpenIdSabreAuthBackend extends AbstractBearer {
 	protected function validateBearerToken($bearerToken) {
 		if ($this->userSession->isLoggedIn() &&
 			$this->isDavAuthenticated($this->userSession->getUser()->getUID())) {
+			try {
 
-			// verify the bearer token
-			$tokenUser = $this->authModule->authToken($bearerToken);
-			if ($tokenUser === null) {
+				// verify the bearer token
+				$tokenUser = $this->authModule->authToken($bearerToken);
+				if ($tokenUser === null) {
+					return false;
+				}
+
+				// setup the user
+				$userId = $this->userSession->getUser()->getUID();
+				$this->setupFilesystem($userId);
+				$this->session->close();
+				return $this->principalPrefix . $userId;
+			} catch (\Exception $ex) {
+				$this->session->close();
 				return false;
 			}
-
-			// setup the user
-			$userId = $this->userSession->getUser()->getUID();
-			$this->setupFilesystem($userId);
-			$this->session->close();
-			return $this->principalPrefix . $userId;
 		}
 
 		$this->setupFilesystem();


### PR DESCRIPTION
…th backend for openidconnect

## Description
token expiry shall not lead to 500 but a proper 401

## Related Issue
- Fixes #86 
- Fixes #106 

## How Has This Been Tested?
- :hand: 
- unit tests added

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
