### PR TITLE
Auto provisioning mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,30 @@ $CONFIG = [
 ];
 ```
 
+### Setup auto provisioning mode
+The auto provisioning mode will create a user based on the provided user information as returned by the OpenID Connect provider.
+The config parameters 'mode' and 'search-attribute' will be used to create a unique user so that the lookup mechanism can find the user again.
+```php
+<?php
+$CONFIG = [
+  'openid-connect' => [
+    'auto-provision' => [
+      // explicit enable the auto provisioning mode
+      'enable' => true, 
+      // documentation about standard claims: https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+      // only relevant in userid mode,  defines the claim which holds the email of the user
+      'email-claim' => 'email', 
+      // defines the claim which holds the display name of the user
+      'display-name-claim' => 'given_name', 
+      // defines the claim which holds the picture of the user - must be a URL
+      'picture-claim' => 'picture', 
+      // defines a list of groups to which the newly created user will be added automatically
+      'groups' => ['admin', 'guests', 'employees'], 
+    ]
+  ]
+];
+```
+
 #### All Configuration Values explained
 
 - loginButtonName - the name as displayed on the login screen which is used to redirect to the IdP

--- a/lib/Service/AutoProvisioningService.php
+++ b/lib/Service/AutoProvisioningService.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license GPL-2.0
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\OpenIdConnect\Service;
+
+use OC\User\LoginException;
+use OCP\Http\Client\IClientService;
+use OCP\IAvatarManager;
+use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\ILogger;
+use OCP\IUser;
+use OCP\IUserManager;
+
+class AutoProvisioningService {
+
+	/**
+	 * @var IUserManager
+	 */
+	private $userManager;
+	/**
+	 * @var IGroupManager
+	 */
+	private $groupManager;
+	/**
+	 * @var IAvatarManager
+	 */
+	private $avatarManager;
+	/**
+	 * @var ILogger
+	 */
+	private $logger;
+	/**
+	 * @var IConfig
+	 */
+	private $config;
+	/**
+	 * @var IClientService
+	 */
+	private $clientService;
+
+	public function __construct(IUserManager $userManager,
+								IGroupManager $groupManager,
+								IAvatarManager $avatarManager,
+								IClientService $clientService,
+								ILogger $logger,
+								IConfig $config) {
+		$this->userManager = $userManager;
+		$this->groupManager = $groupManager;
+		$this->avatarManager = $avatarManager;
+		$this->logger = $logger;
+		$this->config = $config;
+		$this->clientService = $clientService;
+	}
+
+	public function createUser($userInfo): IUser {
+		if (!$this->enabled()) {
+			throw new LoginException('Auto provisioning is disabled.');
+		}
+		$attribute = $this->identityClaim();
+		$emailOrUserId = $userInfo->$attribute ?? null;
+		if (!$emailOrUserId) {
+			throw new LoginException("Configured attribute $attribute is not known.");
+		}
+		$userId = $this->mode() === 'email' ? \uniqid('oidc-user-') : $emailOrUserId;
+		$passwd = \uniqid('', true);
+		$email = $this->mode() === 'email' ? $emailOrUserId : null;
+		$user = $this->userManager->createUser($userId, $passwd);
+		if (!$user) {
+			throw new LoginException("Unable to create user $userId");
+		}
+		$user->setEnabled(true);
+		$openIdConfig = $this->getOpenIdConfiguration();
+		if ($email) {
+			$user->setEMailAddress($email);
+		} else {
+			$emailClaim = $openIdConfig['auto-provision']['email-claim'] ?? null;
+			if ($emailClaim) {
+				$user->setEMailAddress($userInfo->$emailClaim);
+			}
+		}
+
+		$displayNameClaim = $openIdConfig['auto-provision']['display-name-claim'] ?? null;
+		if ($displayNameClaim) {
+			$user->setDisplayName($userInfo->$displayNameClaim);
+		}
+		$groups = $openIdConfig['auto-provision']['groups'] ?? [];
+		foreach ($groups as $group) {
+			$g = $this->groupManager->get($group);
+			if ($g) {
+				$g->addUser($user);
+			}
+		}
+		$pictureClaim = $openIdConfig['auto-provision']['picture-claim'] ?? null;
+		if ($pictureClaim) {
+			$pictureUrl = $userInfo->$pictureClaim;
+			try {
+				$resource = $this->downloadPicture($pictureUrl);
+				$av = $this->avatarManager->getAvatar($user->getUID());
+				$av->set($resource);
+			} catch (\Exception $ex) {
+				$this->logger->logException($ex, [
+					'message' => "Error setting profile picture $pictureUrl"
+				]);
+			}
+		}
+
+		return $user;
+	}
+	public function getOpenIdConfiguration(): array {
+		return $this->config->getSystemValue('openid-connect', null) ?? [];
+	}
+
+	public function enabled(): bool {
+		return $this->getOpenIdConfiguration()['auto-provision']['enabled'] ?? false;
+	}
+
+	private function mode() {
+		return $this->getOpenIdConfiguration()['mode'] ?? 'userid';
+	}
+
+	private function identityClaim() {
+		return $this->getOpenIdConfiguration()['search-attribute'] ?? 'email';
+	}
+
+	protected function downloadPicture(string $pictureUrl) {
+		$response = $this->clientService->newClient()->get($pictureUrl);
+		return $response->getBody();
+	}
+}

--- a/tests/unit/Service/AutoProvisioningServiceTest.php
+++ b/tests/unit/Service/AutoProvisioningServiceTest.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license GPL-2.0
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\OpenIdConnect\Tests\Unit\Service;
+
+use OC\Avatar;
+use OC\User\LoginException;
+use OCA\OpenIdConnect\Service\AutoProvisioningService;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\Http\Client\IResponse;
+use OCP\IAvatar;
+use OCP\IAvatarManager;
+use OCP\IConfig;
+use OCP\IGroup;
+use OCP\IGroupManager;
+use OCP\ILogger;
+use OCP\IUser;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class AutoProvisioningServiceTest extends TestCase {
+
+	/**
+	 * @var IUserManager|MockObject
+	 */
+	private $userManager;
+	/**
+	 * @var IGroupManager|MockObject
+	 */
+	private $groupManager;
+	/**
+	 * @var IAvatarManager|MockObject
+	 */
+	private $avatarManager;
+	/**
+	 * @var ILogger|MockObject
+	 */
+	private $logger;
+	/**
+	 * @var IConfig|MockObject
+	 */
+	private $config;
+	/**
+	 * @var AutoProvisioningService
+	 */
+	private $autoProvisioningService;
+	/**
+	 * @var IClientService|MockObject
+	 */
+	private $clientService;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->avatarManager = $this->createMock(IAvatarManager::class);
+		$this->clientService = $this->createMock(IClientService::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->config = $this->createMock(IConfig::class);
+
+		$this->autoProvisioningService = new AutoProvisioningService($this->userManager,
+			$this->groupManager,
+			$this->avatarManager,
+			$this->clientService,
+			$this->logger,
+			$this->config
+		);
+	}
+
+	/**
+	 * @dataProvider providesConfig
+	 * @param bool $expected
+	 * @param array|null $config
+	 */
+	public function testEnabled(bool $expected, array $config = null): void {
+		$this->config->method('getSystemValue')->willReturn($config);
+		self::assertEquals($expected, $this->autoProvisioningService->enabled());
+	}
+
+	public function providesConfig(): array {
+		return [
+			[false, null],
+			[false, []],
+			[false, ['auto-provision' => []]],
+			[false, ['auto-provision' => ['enabled' => false]]],
+			[true, ['auto-provision' => ['enabled' => true]]],
+		];
+	}
+
+	/**
+	 * @dataProvider providesProvisioningData
+	 * @param bool $expectsUserToBeCreated
+	 * @param bool $expectEmailToBeSet
+	 * @param bool $expectDisplayName
+	 * @param bool $expectsAvatar
+	 * @param bool $expectsGroupMembership
+	 * @param array $config
+	 * @param object $userInfo
+	 * @throws LoginException
+	 */
+	public function testCreateUser(bool $expectsUserToBeCreated,
+								   bool $expectEmailToBeSet,
+								   bool $expectDisplayName,
+								   bool $expectsAvatar, bool $expectsGroupMembership,
+								   array $config, object $userInfo): void {
+		if ($expectsUserToBeCreated) {
+			$user = $this->createMock(IUser::class);
+			$user->expects($expectEmailToBeSet ? self::once() : self::never())->method('setEMailAddress');
+			$user->expects($expectDisplayName ? self::once() : self::never())->method('setDisplayName');
+			$this->userManager->expects(self::once())->method('createUser')->willReturn($user);
+			if ($expectsAvatar) {
+				$resp = $this->createMock(IResponse::class);
+				$resp->expects(self::once())->method('getBody')->willReturn('123456');
+				$client = $this->createMock(IClient::class);
+				$client->expects(self::once())->method('get')->willReturn($resp);
+				$this->clientService->expects(self::once())->method('newClient')->willReturn($client);
+
+				$avatar = $this->createMock(IAvatar::class);
+				$avatar->expects(self::once())->method('set')->with('123456');
+				$this->avatarManager->expects(self::once())->method('getAvatar')->willReturn($avatar);
+			}
+			if ($expectsGroupMembership) {
+				$group = $this->createMock(IGroup::class);
+				$group->expects(self::once())->method('addUser');
+				$this->groupManager->expects(self::once())->method('get')->with('oidc-group')->willReturn($group);
+			}
+		} else {
+			$this->expectException(LoginException::class);
+		}
+		$this->config->method('getSystemValue')->willReturn($config);
+		$this->autoProvisioningService->createUser($userInfo);
+	}
+
+	public function providesProvisioningData(): array {
+		return [
+			[false, false, false, false, false, [], (object)['email' => 'alice@example.net']],
+			[false, false, false, false, false, ['auto-provision' => ['enabled' => true]], (object)['email' => 'alice@example.net']],
+			[false, false, false, false, false, ['auto-provision' => ['enabled' => true]], (object)[]],
+			[true, false, false, false, false, ['auto-provision' => ['enabled' => true]], (object)['email' => 'alice@example.net']],
+			[true, true, false, false, false, ['auto-provision' => ['enabled' => true, 'email-claim' => 'email']], (object)['email' => 'alice@example.net']],
+			[true, true, false, false, false, ['mode' => 'email', 'auto-provision' => ['enabled' => true]], (object)['email' => 'alice@example.net']],
+			[true, false, true, false, false, ['mode' => 'userid', 'auto-provision' => ['enabled' => true, 'display-name-claim' => 'name']], (object)['email' => 'alice@example.net', 'name' => 'Alice']],
+			[true, false, false, true, false, ['mode' => 'userid', 'auto-provision' => ['enabled' => true, 'picture-claim' => 'picture']], (object)['email' => 'alice@example.net', 'picture' => 'http://']],
+			[true, false, false, false, true, ['mode' => 'userid', 'auto-provision' => ['enabled' => true, 'groups' => ['oidc-group']]], (object)['email' => 'alice@example.net', 'picture' => 'http://']],
+		];
+	}
+}

--- a/tests/unit/Service/UserLookupServiceTest.php
+++ b/tests/unit/Service/UserLookupServiceTest.php
@@ -25,6 +25,7 @@ namespace OCA\OpenIdConnect\Tests\Unit\Service;
 use OC\HintException;
 use OC\User\LoginException;
 use OCA\OpenIdConnect\Client;
+use OCA\OpenIdConnect\Service\AutoProvisioningService;
 use OCA\OpenIdConnect\Service\UserLookupService;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -45,13 +46,18 @@ class UserLookupServiceTest extends TestCase {
 	 * @var MockObject | IUserManager
 	 */
 	private $manager;
+	/**
+	 * @var AutoProvisioningService|MockObject
+	 */
+	private $autoProvisioningService;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->client = $this->createMock(Client::class);
 		$this->manager = $this->createMock(IUserManager::class);
+		$this->autoProvisioningService = $this->createMock(AutoProvisioningService::class);
 
-		$this->userLookup = new UserLookupService($this->manager, $this->client);
+		$this->userLookup = new UserLookupService($this->manager, $this->client, $this->autoProvisioningService);
 	}
 
 	public function testNotConfigured(): void {


### PR DESCRIPTION
## Description
Once the auto provisioning mode is enabled a local user will be created based on the user information as provided by the user info endpoint of the OpenID Connect Provider

Fixes https://github.com/owncloud/openidconnect/issues/85

## How Has This Been Tested?
- :robot: 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

