### PR TITLE
[tests-only] Bump phan from 2.7 to 3.2

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
     <name>OpenID Connect</name>
     <summary>Authentication and SSO with OpenID Connect (OIDC)</summary>
     <description>
-This extension adds support for [OpenID Connect](https://openid.net/connect/) to ownCloud Server. 
+This extension adds support for [OpenID Connect](https://openid.net/connect/) to ownCloud Server.
 
 OpenID Connect is an open standard for single sign-on and identity and access management. With ownCloud it can be used for user authentication and client authorization against an external Identity Provider.
 
@@ -31,6 +31,7 @@ More information on setup, configuration and migration can be found in the ownCl
     <screenshot>https://raw.githubusercontent.com/owncloud/screenshots/master/openidconnect/openidconnect.png</screenshot>
     <dependencies>
         <owncloud min-version="10" max-version="10"/>
+        <php min-version="7.1" />
     </dependencies>
     <types>
         <authentication/>

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "library",
     "description": "OpenId Connect app for ownCloud",
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "jumbojett/openid-connect-php": "^0.9.0"
     },
     "require-dev": {
@@ -25,7 +25,7 @@
         "optimize-autoloader": true,
         "classmap-authoritative": false,
         "platform": {
-            "php": "7.0.8"
+            "php": "7.1"
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "578907f243ddf227a4a9a44f373950de",
+    "content-hash": "565176544e66fd24dd9a2f8979d95dcb",
     "packages": [
         {
             "name": "jumbojett/openid-connect-php",
@@ -42,6 +42,10 @@
                 "Apache-2.0"
             ],
             "description": "Bare-bones OpenID Connect client",
+            "support": {
+                "issues": "https://github.com/jumbojett/OpenID-Connect-PHP/issues",
+                "source": "https://github.com/jumbojett/OpenID-Connect-PHP/tree/v0.9.2"
+            },
             "time": "2020-11-16T14:48:22+00:00"
         },
         {
@@ -87,6 +91,11 @@
                 "pseudorandom",
                 "random"
             ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/random_compat/issues",
+                "source": "https://github.com/paragonie/random_compat"
+            },
             "time": "2020-10-15T08:29:30+00:00"
         },
         {
@@ -178,6 +187,10 @@
                 "x.509",
                 "x509"
             ],
+            "support": {
+                "issues": "https://github.com/phpseclib/phpseclib/issues",
+                "source": "https://github.com/phpseclib/phpseclib/tree/2.0"
+            },
             "funding": [
                 {
                     "url": "https://github.com/terrafrost",
@@ -240,6 +253,10 @@
                 "isolation",
                 "tool"
             ],
+            "support": {
+                "issues": "https://github.com/bamarni/composer-bin-plugin/issues",
+                "source": "https://github.com/bamarni/composer-bin-plugin/tree/master"
+            },
             "time": "2020-05-03T08:27:20+00:00"
         }
     ],
@@ -249,11 +266,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0"
+        "php": ">=7.1"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.0.8"
+        "php": "7.1"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/vendor-bin/phan/composer.json
+++ b/vendor-bin/phan/composer.json
@@ -1,5 +1,5 @@
 {
   "require": {
-    "phan/phan": "^2.7"
+    "phan/phan": "^3.2"
   }
 }


### PR DESCRIPTION
This has been done in some other oC10 app repos. Do it here similar to https://github.com/owncloud/core/pull/38122

PR #53 introduced the use of function return type `void` - https://www.php.net/manual/en/migration71.new-features.php

The new phan 3.2 notices that `composer.json` allows PHP 7.0 and it complains about those:
```
[debug] Running '/usr/bin/php7.4' '-n' '-c' '/tmp/rpwlhq' 'vendor-bin/phan/vendor/bin/phan' '--config-file' '.phan/config.php' '--require-config-exists'
   analyze ████████████████████████████████████████████████████████████ 100.0% 848MB/861MB
lib/Application.php:50 PhanCompatibleVoidTypePHP70 Return type 'void' means the absence of a return value starting in PHP 7.1. In PHP 7.0, void refers to a class/interface with the name 'void'
lib/EventHandler.php:53 PhanCompatibleVoidTypePHP70 Return type 'void' means the absence of a return value starting in PHP 7.1. In PHP 7.0, void refers to a class/interface with the name 'void'
lib/LoginPageBehaviour.php:49 PhanCompatibleVoidTypePHP70 Return type 'void' means the absence of a return value starting in PHP 7.1. In PHP 7.0, void refers to a class/interface with the name 'void'
lib/LoginPageBehaviour.php:79 PhanCompatibleVoidTypePHP70 Return type 'void' means the absence of a return value starting in PHP 7.1. In PHP 7.0, void refers to a class/interface with the name 'void'
lib/LoginPageBehaviour.php:88 PhanCompatibleVoidTypePHP70 Return type 'void' means the absence of a return value starting in PHP 7.1. In PHP 7.0, void refers to a class/interface with the name 'void'
lib/OpenIdConnectAuthModule.php:81 PhanCompatibleNullableTypePHP70 Nullable type '?\OCP\IUser' is not compatible with PHP 7.0
lib/OpenIdConnectAuthModule.php:95 PhanCompatibleNullableTypePHP70 Nullable type '?\OCP\IUser' is not compatible with PHP 7.0
lib/OpenIdConnectAuthModule.php:202 PhanCompatibleVoidTypePHP70 Return type 'void' means the absence of a return value starting in PHP 7.1. In PHP 7.0, void refers to a class/interface with the name 'void'
lib/Sabre/OpenIdSabreAuthBackend.php:156 PhanCompatibleVoidTypePHP70 Return type 'void' means the absence of a return value starting in PHP 7.1. In PHP 7.0, void refers to a class/interface with the name 'void'
lib/Service/UserLookupService.php:86 PhanCompatibleVoidTypePHP70 Return type 'void' means the absence of a return value starting in PHP 7.1. In PHP 7.0, void refers to a class/interface with the name 'void'
lib/SessionVerifier.php:64 PhanCompatibleVoidTypePHP70 Return type 'void' means the absence of a return value starting in PHP 7.1. In PHP 7.0, void refers to a class/interface with the name 'void'
lib/SessionVerifier.php:134 PhanCompatibleVoidTypePHP70 Return type 'void' means the absence of a return value starting in PHP 7.1. In PHP 7.0, void refers to a class/interface with the name 'void'
lib/SessionVerifier.php:165 PhanCompatibleVoidTypePHP70 Return type 'void' means the absence of a return value starting in PHP 7.1. In PHP 7.0, void refers to a class/interface with the name 'void'
lib/SessionVerifier.php:187 PhanCompatibleVoidTypePHP70 Return type 'void' means the absence of a return value starting in PHP 7.1. In PHP 7.0, void refers to a class/interface with the name 'void'
[debug] Restarted process exited 1
Makefile:129: recipe for target 'test-php-phan' failed
make: *** [test-php-phan] Error 1
```

This app will not run nicely on PHP  7.0. So bumped the PHP min-version to 7.1