### PR TITLE
Store redirect url in session

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -22,6 +22,7 @@
 namespace OCA\OpenIdConnect;
 
 use Jumbojett\OpenIDConnectClient;
+use Jumbojett\OpenIDConnectClientException;
 use OCP\IConfig;
 use OCP\ISession;
 use OCP\IURLGenerator;
@@ -89,7 +90,7 @@ class Client extends OpenIDConnectClient {
 	}
 
 	/**
-	 * @throws \Jumbojett\OpenIDConnectClientException
+	 * @throws OpenIDConnectClientException
 	 */
 	public function getWellKnownConfig() {
 		if (!$this->wellKnownConfig) {
@@ -106,6 +107,16 @@ class Client extends OpenIDConnectClient {
 		}
 
 		return $this->requestUserInfo();
+	}
+
+	public function storeRedirectUrl(?string $redirectUrl): void {
+		if ($redirectUrl) {
+			$this->setSessionKey('openid_connect_redirect_url', $redirectUrl);
+		}
+	}
+
+	public function readRedirectUrl(): ?string {
+		return $this->getSessionKey('openid_connect_redirect_url');
 	}
 
 	/**
@@ -151,6 +162,9 @@ class Client extends OpenIDConnectClient {
 
 	/**
 	 * @codeCoverageIgnore
+	 *
+	 * @return bool
+	 * @throws OpenIDConnectClientException
 	 */
 	public function authenticate() : bool {
 		$redirectUrl = $this->generator->linkToRouteAbsolute('openidconnect.loginFlow.login');

--- a/lib/Controller/LoginFlowController.php
+++ b/lib/Controller/LoginFlowController.php
@@ -121,6 +121,7 @@ class LoginFlowController extends Controller {
 		}
 		try {
 			$this->logger->debug('Before openid->authenticate');
+			$openid->storeRedirectUrl($this->request->getParam('redirect_url'));
 			$openid->authenticate();
 		} catch (OpenIDConnectClientException $ex) {
 			$this->logger->logException($ex);
@@ -220,6 +221,14 @@ class LoginFlowController extends Controller {
 	 * @return string
 	 */
 	protected function getDefaultUrl(): string {
+		$openid = $this->getOpenIdConnectClient();
+		if ($openid) {
+			$redirectUrl = $openid->readRedirectUrl();
+			if ($redirectUrl) {
+				$_REQUEST['redirect_url'] = $redirectUrl;
+			}
+		}
+
 		return \OC_Util::getDefaultPageUrl();
 	}
 

--- a/lib/LoginPageBehaviour.php
+++ b/lib/LoginPageBehaviour.php
@@ -67,7 +67,7 @@ class LoginPageBehaviour {
 		if (\substr($uri, -6) === '/login') {
 			$req = $this->request->getRequestUri();
 			$this->logger->debug("Redirecting to IdP - request url: $req");
-			$loginUrl = $this->urlGenerator->linkToRoute('openidconnect.loginFlow.login');
+			$loginUrl = $this->urlGenerator->linkToRoute('openidconnect.loginFlow.login', $this->request->getParams());
 			$this->redirect($loginUrl);
 		}
 	}
@@ -88,7 +88,7 @@ class LoginPageBehaviour {
 	public function registerAlternativeLogin(string $loginName): void {
 		OC_App::registerLogIn([
 			'name' => $loginName,
-			'href' => $this->urlGenerator->linkToRoute('openidconnect.loginFlow.login'),
+			'href' => $this->urlGenerator->linkToRoute('openidconnect.loginFlow.login', $this->request->getParams()),
 		]);
 	}
 }


### PR DESCRIPTION
## Description
Follow up  of #129 
The redirect url is stored in the session ans it not leaving the server. 
Tested with Azure AD - should work with any IdP

## Related Issue
- Fixes #128 

## How Has This Been Tested?
- in a private tab
- open a url to somewhere within owncloud - e.g. settings page https://own.cloud/index.php/settings/personal#
- process the soo flow
- be finally redirected to the originally requested page

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
