### PR TITLE
AutoProvisioning based on a Provisioning Claim

### DIFF
--- a/lib/Service/AutoProvisioningService.php
+++ b/lib/Service/AutoProvisioningService.php
@@ -80,6 +80,17 @@ class AutoProvisioningService {
 		if (!$emailOrUserId) {
 			throw new LoginException("Configured attribute $attribute is not known.");
 		}
+
+        $openIdConfig = $this->getOpenIdConfiguration();
+        $provisioningClaim = $openIdConfig['auto-provision']['provisioning-claim'] ?? null;
+        if ($provisioningClaim) {
+                $this->logger->debug('ProvisioningClaim is defined for auto-provision');
+                $provisioningAttribute = $openIdConfig['auto-provision']['provisioning-attribute'] ?? null;
+                if (! \in_array($provisioningAttribute, $userInfo->$provisioningClaim, true)) {
+                        throw new LoginException("Required provisioning attribute is not found.");
+                }
+        }
+
 		$userId = $this->mode() === 'email' ? \uniqid('oidc-user-') : $emailOrUserId;
 		$passwd = \uniqid('', true);
 		$email = $this->mode() === 'email' ? $emailOrUserId : null;
@@ -88,7 +99,7 @@ class AutoProvisioningService {
 			throw new LoginException("Unable to create user $userId");
 		}
 		$user->setEnabled(true);
-		$openIdConfig = $this->getOpenIdConfiguration();
+
 		if ($email) {
 			$user->setEMailAddress($email);
 		} else {

--- a/lib/Service/AutoProvisioningService.php
+++ b/lib/Service/AutoProvisioningService.php
@@ -81,15 +81,15 @@ class AutoProvisioningService {
 			throw new LoginException("Configured attribute $attribute is not known.");
 		}
 
-        $openIdConfig = $this->getOpenIdConfiguration();
-        $provisioningClaim = $openIdConfig['auto-provision']['provisioning-claim'] ?? null;
-        if ($provisioningClaim) {
-                $this->logger->debug('ProvisioningClaim is defined for auto-provision');
-                $provisioningAttribute = $openIdConfig['auto-provision']['provisioning-attribute'] ?? null;
-                if (! \in_array($provisioningAttribute, $userInfo->$provisioningClaim, true)) {
-                        throw new LoginException("Required provisioning attribute is not found.");
-                }
-        }
+		$openIdConfig = $this->getOpenIdConfiguration();
+		$provisioningClaim = $openIdConfig['auto-provision']['provisioning-claim'] ?? null;
+		if ($provisioningClaim) {
+			$this->logger->debug('ProvisioningClaim is defined for auto-provision');
+			$provisioningAttribute = $openIdConfig['auto-provision']['provisioning-attribute'] ?? null;
+			if (! \in_array($provisioningAttribute, $userInfo->$provisioningClaim, true)) {
+				throw new LoginException("Required provisioning attribute is not found.");
+			}
+		}
 
 		$userId = $this->mode() === 'email' ? \uniqid('oidc-user-') : $emailOrUserId;
 		$passwd = \uniqid('', true);


### PR DESCRIPTION
## Description
Allow Auto Provisioning on based of a specific OpenID Connect provisioning claim

## Related Issue
- Fixes https://github.com/owncloud/openidconnect/issues/149

## Motivation and Context
For the Dutch Sync-And-Share service, we requires an specific OpenID Connect claim on which basis we do auto provisioning of a user. See also; https://wiki.surfnet.nl/display/surfconextdev/Attributes+in+SURFconext#AttributesinSURFconext-eduPersonEntitlementEntitlements

## How Has This Been Tested?
 - Tested with an account with the required provisioning claim
 - Tested with an account without the required provisioning claim
 - Tested without the provisioning claim defined

## Screenshots (if appropriate):


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
