### PR TITLE
Autoprovisionining based on claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Use random_bytes to generate auto-provisioning user-id and password - [#154](https://github.com/owncloud/openidconnect/issues/154)
 
+- Provision accounts based on auto-provisioning claim - [#149](https://github.com/owncloud/openidconnect/issues/149)
+
 ## [2.0.0] - 2021-01-10
 
 ### Added

--- a/tests/unit/Service/AutoProvisioningServiceTest.php
+++ b/tests/unit/Service/AutoProvisioningServiceTest.php
@@ -163,6 +163,11 @@ class AutoProvisioningServiceTest extends TestCase {
 			[true, false, true, false, false, ['mode' => 'userid', 'auto-provision' => ['enabled' => true, 'display-name-claim' => 'name']], (object)['email' => 'alice@example.net', 'name' => 'Alice']],
 			[true, false, false, true, false, ['mode' => 'userid', 'auto-provision' => ['enabled' => true, 'picture-claim' => 'picture']], (object)['email' => 'alice@example.net', 'picture' => 'http://']],
 			[true, false, false, false, true, ['mode' => 'userid', 'auto-provision' => ['enabled' => true, 'groups' => ['oidc-group']]], (object)['email' => 'alice@example.net', 'picture' => 'http://']],
+			[true, false, false, false, false, ['auto-provision' => ['enabled' => true, 'provisioning-claim' => 'foo', 'provisioning-attribute' => 'bar']], (object)['email' => 'alice@example.net', 'foo' => ['bar']]],
+			[false, false, false, false, false, ['auto-provision' => ['enabled' => true, 'provisioning-claim' => 'foo']], (object)['email' => 'alice@example.net', 'foo' => ['bar']]],
+			[false, false, false, false, false, ['auto-provision' => ['enabled' => true, 'provisioning-claim' => 'foo']], (object)['email' => 'alice@example.net', 'foo' => 'must-be-array']],
+			[false, false, false, false, false, ['auto-provision' => ['enabled' => true, 'provisioning-claim' => 'foo']], (object)['email' => 'alice@example.net', 'foo' => null]],
+			[false, false, false, false, false, ['auto-provision' => ['enabled' => true, 'provisioning-claim' => 'foo']], (object)['email' => 'alice@example.net']],
 		];
 	}
 }


### PR DESCRIPTION
## Description
Allow Auto Provisioning on based of a specific OpenID Connect provisioning claim

## Related Issue
- Fixes https://github.com/owncloud/openidconnect/issues/149

## Motivation and Context
For the Dutch Sync-And-Share service, we requires an specific OpenID Connect claim on which basis we do auto provisioning of a user. See also; https://wiki.surfnet.nl/display/surfconextdev/Attributes+in+SURFconext#AttributesinSURFconext-eduPersonEntitlementEntitlements

## How Has This Been Tested?
 - Tested with an account with the required provisioning claim
 - Tested with an account without the required provisioning claim
 - Tested without the provisioning claim defined

## Screenshots (if appropriate):


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests
