### PR TITLE
[tests-only] Remove dav.enable.tech_preview from CI

### DIFF
--- a/tests/docker/owncloud/phoenix.config.php
+++ b/tests/docker/owncloud/phoenix.config.php
@@ -1,5 +1,4 @@
 <?php
 $CONFIG = [
-	'cors.allowed-domains' => ['http://10.254.254.254:8300'],
-	'dav.enable.tech_preview' => true
+	'cors.allowed-domains' => ['http://10.254.254.254:8300']
 ];


### PR DESCRIPTION
## Description
`dav.enable.tech_preview` was used in about ownCloud server 10.4. We don't need to use that setting in CI any more, so remove it.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
