### PR TITLE
Add setting to use id-token payload for userinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ $CONFIG = [
 - search-attribute - the attribute which is taken from the access token JWT or user info endpoint to identify the user
 - allowed-user-backends - limit the users which are allowed to login to a specific user backend - e.g. LDAP
 - use-access-token-payload-for-user-info - if set to true any user information will be read from the access token. If set to false the userinfo endpoint is used (starting app version 1.1.0)
-
+- use-id-token-payload-for-user-info - if set to true any user information will be read from the access token. If set to false the userinfo endpoint is used (starting app version 1.1.0)
 
 ### Setup within the OpenId Provider
 When registering ownCloud as OpenId Client use ```https://cloud.example.net/index.php/apps/openidconnect/redirect``` as redirect url .

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -127,6 +127,10 @@ class Client extends OpenIDConnectClient {
 			return $this->getAccessTokenPayload();
 		}
 
+		if (isset($openIdConfig['use-id-token-payload-for-user-info']) && $openIdConfig['use-id-token-payload-for-user-info']) {
+			return $this->getIdTokenPayload();
+		}
+
 		return $this->requestUserInfo();
 	}
 


### PR DESCRIPTION
## Description
Add a setting to get userinfo from the id-token.

## Motivation and Context
Some IDPs which require a [Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693) return an opaque access-token which is already expired, so 
no introspection is possible. The userinfo endpoint is disabled in this case. 

The JWT with the userinfo is the id-token instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
