### PR TITLE
add owncloud-selector cookie support

### DIFF
--- a/lib/Controller/LoginFlowController.php
+++ b/lib/Controller/LoginFlowController.php
@@ -161,7 +161,15 @@ class LoginFlowController extends Controller {
 			} else {
 				$this->logger->debug('Id token holds no sid: ' . \json_encode($openid->getIdTokenPayload()));
 			}
-			return new RedirectResponse($this->getDefaultUrl());
+			$response = new RedirectResponse($this->getDefaultUrl());
+			$openIdConfig = $openid->getOpenIdConfig();
+			$cookieName = $openIdConfig['ocis-routing-policy-cookie'] ?? 'owncloud-selector';
+			$cookieDirectives = $openIdConfig['ocis-routing-policy-cookie-directives'] ?? 'path=/;';
+			$attribute = $openIdConfig['ocis-routing-poclicy-claim'] ?? 'ocis.routing.policy';
+			if (\property_exists($userInfo, $attribute)) {
+				$response->addHeader('Set-Cookie', "$cookieName={$userInfo->$attribute};$cookieDirectives");
+			}
+			return $response;
 		}
 		$this->logger->error("Unable to login {$user->getUID()}");
 		return new RedirectResponse('/');

--- a/tests/unit/Controller/LoginFlowControllerLoginTest.php
+++ b/tests/unit/Controller/LoginFlowControllerLoginTest.php
@@ -184,4 +184,29 @@ class LoginFlowControllerLoginTest extends TestCase {
 
 		self::assertEquals('http://localhost/index.php/apps/oauth2/foo/bla', $response->getRedirectURL());
 	}
+
+	public function testLoginCreateSuccessWithOCISRoutingPolicyCookie(): void {
+		$this->client->method('getOpenIdConfig')->willReturn([]);
+		$this->client->method('getUserInfo')->willReturn((object)['email' => 'foo@exmaple.net','ocis.routing.policy'=>'ocis']);
+		$this->client->method('getIdToken')->willReturn('id');
+		$this->client->method('getAccessToken')->willReturn('access');
+		$this->client->method('getRefreshToken')->willReturn('refresh');
+		$this->client->method('readRedirectUrl')->willReturn('index.php/apps/oauth2/foo/bla');
+		$user = $this->createMock(IUser::class);
+		$this->userLookup->method('lookupUser')->willReturn($user);
+		$this->userSession->method('createSessionToken')->willReturn(true);
+		$this->userSession->method('loginUser')->willReturn(true);
+		$this->session->expects(self::exactly(3))->method('set')->withConsecutive(
+			['oca.openid-connect.id-token', 'id'],
+			['oca.openid-connect.access-token', 'access'],
+			['oca.openid-connect.refresh-token', 'refresh']
+		);
+
+		$response = $this->controller->login();
+
+		self::assertEquals('http://localhost/index.php/apps/oauth2/foo/bla', $response->getRedirectURL());
+
+		$headers = $response->getHeaders();
+		self::assertEquals('owncloud-selector=ocis;path=/;', $headers['Set-Cookie']);
+	}
 }


### PR DESCRIPTION
For the [live migration](https://github.com/owncloud/ocis/pull/2302) we are reading a claim from the openid connect userinfo to set the `owncloud-selector` cookie that the proxy uses to route requests to ocis or oc10.

The response we need to react to is the redirect from the IdP which looks like
`https://cloud.ocis.test/apps/openidconnect/redirect?code=fooberbazrandombytes&scope=openid%20profile%20email&session_state=some.jwt.token%3D&state=something`

There is no Authorization Bearer header set, yet so we cannot set the cookie in the proxy. For now, the best place to put the code is the openidconnect app.

