### PR TITLE
fix: only register the alternative login method on login page and GET…

### DIFF
--- a/lib/LoginPageBehaviour.php
+++ b/lib/LoginPageBehaviour.php
@@ -53,6 +53,17 @@ class LoginPageBehaviour {
 		if ($this->userSession->isLoggedIn()) {
 			return;
 		}
+		# only GET requests are of interest
+		if ($this->request->getMethod() !== 'GET') {
+			return;
+		}
+		# only requests on the login page are of interest
+		$components = \parse_url($this->request->getRequestUri());
+		/** @phan-suppress-next-line PhanTypePossiblyInvalidDimOffset */
+		$uri = $components['path'];
+		if (\substr($uri, -6) !== '/login') {
+			return;
+		}
 
 		// register alternative login
 		$loginName = $openIdConfig['loginButtonName'] ?? 'OpenID Connect';
@@ -63,15 +74,11 @@ class LoginPageBehaviour {
 		if (!$autoRedirectOnLoginPage) {
 			return;
 		}
-		$components = \parse_url($this->request->getRequestUri());
-		/** @phan-suppress-next-line PhanTypePossiblyInvalidDimOffset */
-		$uri = $components['path'];
-		if (\substr($uri, -6) === '/login') {
-			$req = $this->request->getRequestUri();
-			$this->logger->debug("Redirecting to IdP - request url: $req");
-			$loginUrl = $this->urlGenerator->linkToRoute('openidconnect.loginFlow.login', $this->request->getParams());
-			$this->redirect($loginUrl);
-		}
+
+		$req = $this->request->getRequestUri();
+		$this->logger->debug("Redirecting to IdP - request url: $req");
+		$loginUrl = $this->urlGenerator->linkToRoute('openidconnect.loginFlow.login', $this->request->getParams());
+		$this->redirect($loginUrl);
 	}
 
 	/**


### PR DESCRIPTION
… requests
## Description
The sso login button is only setup for GET requests and on the login page

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/4913

## How Has This Been Tested?
- share folder publicly with upload rights
- try to upload on the public link
- get a 500 on PUT

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
