### PR TITLE
Read openid configuration from DB first before using config.php

### DIFF
--- a/lib/Service/AutoProvisioningService.php
+++ b/lib/Service/AutoProvisioningService.php
@@ -22,10 +22,10 @@
  */
 namespace OCA\OpenIdConnect\Service;
 
+use OCA\OpenIdConnect\Client;
 use OC\User\LoginException;
 use OCP\Http\Client\IClientService;
 use OCP\IAvatarManager;
-use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\ILogger;
 use OCP\IUser;
@@ -50,13 +50,13 @@ class AutoProvisioningService {
 	 */
 	private $logger;
 	/**
-	 * @var IConfig
-	 */
-	private $config;
-	/**
 	 * @var IClientService
 	 */
 	private $clientService;
+	/**
+	 * @var Client
+	 */
+	private $client;
 
 	public function __construct(
 		IUserManager $userManager,
@@ -64,14 +64,14 @@ class AutoProvisioningService {
 		IAvatarManager $avatarManager,
 		IClientService $clientService,
 		ILogger $logger,
-		IConfig $config
+		Client $client
 	) {
 		$this->userManager = $userManager;
 		$this->groupManager = $groupManager;
 		$this->avatarManager = $avatarManager;
 		$this->logger = $logger;
-		$this->config = $config;
 		$this->clientService = $clientService;
+		$this->client = $client;
 	}
 
 	public function createUser($userInfo): IUser {
@@ -146,7 +146,7 @@ class AutoProvisioningService {
 		return $user;
 	}
 	public function getOpenIdConfiguration(): array {
-		return $this->config->getSystemValue('openid-connect', null) ?? [];
+		return $this->client->getOpenIdConfig();
 	}
 
 	public function enabled(): bool {


### PR DESCRIPTION
## Description
Auto-provision is not working when setting the configuration in the database. It only works when you change config.php.
This change is in line with the default behavior for saving OpenID settings (https://doc.owncloud.com/server/next/admin_manual/configuration/user/oidc/oidc.html#save-settings-in-the-database).

## Related Issue
- Fixes #194 (https://github.com/owncloud/openidconnect/issues/194)

## Motivation and Context
Settings the auto-provision using the proposed method (in database) was not working without this change

## How Has This Been Tested?
Log in with a user that not exists resulted in an error (user xxx is not known.)
Applying the changes in this pull request created the user in owncloud.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:

