### PR TITLE
feat: use token exchange before calling the token introspection endpoint

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -2,6 +2,7 @@
 /**
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Miroslav Bauer <Miroslav.Bauer@cesnet.cz>
+ * @author Ilja Neumann <ineumann@owncloud.com>
  *
  * @copyright Copyright (c) 2022, ownCloud GmbH
  * @license GPL-2.0
@@ -140,6 +141,20 @@ class Client extends OpenIDConnectClient {
 			return $this->getAccessTokenPayload();
 		}
 
+		if (isset($openIdConfig['use-access-token-introspection-for-user-info']) && $openIdConfig['use-access-token-introspection-for-user-info']) {
+			$introspectionClientId = $openIdConfig['token-introspection-endpoint-client-id'] ?? null;
+			$introspectionClientSecret = $openIdConfig['token-introspection-endpoint-client-secret'] ?? null;
+			$accessToken = $this->getAccessToken();
+			if (isset($openIdConfig['exchange-token-mode-before-introspection'])) {
+				$mode = $openIdConfig['exchange-token-mode-before-introspection'];
+				$token = $mode === 'refresh-token' ? $this->getRefreshToken() : $this->getAccessToken();
+				$this->logger->debug("Starting token-exchange to get user_info with subject_token mode: $mode");
+				$accessToken = $this->exchangeToken($token, $mode);
+			}
+
+			return $this->introspectToken($accessToken, '', $introspectionClientId, $introspectionClientSecret);
+		}
+
 		return $this->requestUserInfo();
 	}
 
@@ -182,6 +197,29 @@ class Client extends OpenIDConnectClient {
 			return $userInfo->$pictureClaim;
 		}
 		return null;
+	}
+
+	/**
+	 * Perform a RFC8693 Token Exchange
+	 * https://datatracker.ietf.org/doc/html/rfc8693
+	 *
+	 * @param string $subjectToken
+	 * @param string $tokenType Type of the token to exchange 'refresh-token' or 'access-token'
+	 * @return string Access Token
+	 * @throws OpenIDConnectClientException
+	 */
+	public function exchangeToken(string $subjectToken, string $tokenType): string {
+		$subjectTokenType = $tokenType === 'refresh-token' ? 'urn:ietf:params:oauth:token-type:refresh_token' : 'urn:ietf:params:oauth:token-type:access_token';
+		$exchangeResponse = $this->requestTokenExchange($subjectToken, $subjectTokenType, $this->getClientID());
+
+		if (isset($exchangeResponse->error)) {
+			if (isset($exchangeResponse->error_description)) {
+				throw new OpenIDConnectClientException('TokenExchange response: ' . $exchangeResponse->error_description);
+			}
+			throw new OpenIDConnectClientException('TokenExchange response: ' . $exchangeResponse->error);
+		}
+
+		return $exchangeResponse->access_token;
 	}
 
 	public function storeRedirectUrl(?string $redirectUrl): void {


### PR DESCRIPTION
## Description
Adds support for rfc8693

## Motivation and Context
Some IdPs require to perform a token exchange before the introspection endpoint can be called

## How Has This Been Tested?
- customer setup

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
