### PR TITLE
feat: JWT token will always be used for user info, expiry and verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ vendor-bin/**/composer.lock
 /build/
 /tests/output/
 .phpunit.result.cache
+tests/unit/PopTest.php
 
 # SonarCloud scanner
 .scannerwork

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -163,7 +163,9 @@ class Client extends OpenIDConnectClient {
 	public function getUserInfo() {
 		$openIdConfig = $this->getOpenIdConfig();
 		if (isset($openIdConfig['use-access-token-payload-for-user-info']) && $openIdConfig['use-access-token-payload-for-user-info']) {
-			return $this->getAccessTokenPayload();
+			if ($payload = $this->getAccessTokenPayload()) {
+				return $payload;
+			}
 		}
 
 		if (isset($openIdConfig['use-access-token-introspection-for-user-info']) && $openIdConfig['use-access-token-introspection-for-user-info']) {

--- a/lib/OpenIdConnectAuthModule.php
+++ b/lib/OpenIdConnectAuthModule.php
@@ -156,10 +156,10 @@ class OpenIdConnectAuthModule implements IAuthModule {
 		if ($userInfo) {
 			return $userInfo['exp'];
 		}
-		# TODO: add PoP specific verification
 		$config = $this->client->getOpenIdConfig();
-		$useIntrospectionEndpoint = $config['use-token-introspection-endpoint'] ?? false;
-		if ($useIntrospectionEndpoint) {
+		$payload = $this->client->getAccessTokenPayload();
+
+		if (!$payload) {
 			$introspectionClientId = $config['token-introspection-endpoint-client-id'] ?? null;
 			$introspectionClientSecret = $config['token-introspection-endpoint-client-secret'] ?? null;
 

--- a/lib/OpenIdConnectAuthModule.php
+++ b/lib/OpenIdConnectAuthModule.php
@@ -112,8 +112,8 @@ class OpenIdConnectAuthModule implements IAuthModule {
 			if ($this->client->getOpenIdConfig() === null) {
 				return null;
 			}
-			// 1. verify JWT signature
-			$expiry = $this->verifyJWT($type, $token);
+			// 1. verify token
+			$expiry = $this->verifyToken($token);
 
 			// 2. verify expiry
 			if ($expiry) {
@@ -150,40 +150,14 @@ class OpenIdConnectAuthModule implements IAuthModule {
 	/**
 	 * @throws OpenIDConnectClientException
 	 */
-	private function verifyJWT(string $type, string $token) {
+	private function verifyToken(string $token) {
 		$cache = $this->getCache();
 		$userInfo = $cache->get($token);
 		if ($userInfo) {
 			return $userInfo['exp'];
 		}
-		$config = $this->client->getOpenIdConfig();
-		$payload = $this->client->getAccessTokenPayload();
 
-		if (!$payload) {
-			$introspectionClientId = $config['token-introspection-endpoint-client-id'] ?? null;
-			$introspectionClientSecret = $config['token-introspection-endpoint-client-secret'] ?? null;
-
-			$introData = $this->client->introspectToken($token, '', $introspectionClientId, $introspectionClientSecret);
-			$this->logger->debug('Introspection info: ' . \json_encode($introData));
-			if (\property_exists($introData, 'error')) {
-				$this->logger->error('Token introspection failed: ' . \json_encode($introData));
-				throw new OpenIDConnectClientException("Verifying token failed: {$introData->error}");
-			}
-			if (!$introData->active) {
-				$this->logger->error('Token (as per introspection) is inactive: ' . \json_encode($introData));
-				throw new OpenIDConnectClientException('Token (as per introspection) is inactive');
-			}
-			return $introData->exp;
-		}
-		if (!$this->client->verifyJWTsignature($token)) {
-			$this->logger->error('Token cannot be verified: ' . $token);
-			throw new OpenIDConnectClientException('Token cannot be verified.');
-		}
-		$this->client->setAccessToken($token);
-		$payload = $this->client->getAccessTokenPayload();
-		$this->logger->debug('Access token payload: ' . \json_encode($payload));
-		/* @phan-suppress-next-line PhanTypeExpectedObjectPropAccess */
-		return $payload->exp;
+		return $this->client->verifyToken($token);
 	}
 
 	/**

--- a/lib/SessionVerifier.php
+++ b/lib/SessionVerifier.php
@@ -99,7 +99,10 @@ class SessionVerifier {
 
 		$client->setAccessToken($accessToken);
 		$openIdConfig = $client->getOpenIdConfig();
-		if (isset($openIdConfig['use-token-introspection-endpoint']) && $openIdConfig['use-token-introspection-endpoint']) {
+
+		# if the access token is a JWT we use it for verification
+		$payload = $this->client->getAccessTokenPayload();
+		if (!$payload) {
 			$introspectionClientId = $openIdConfig['token-introspection-endpoint-client-id'] ?? null;
 			$introspectionClientSecret = $openIdConfig['token-introspection-endpoint-client-secret'] ?? null;
 

--- a/tests/docker/owncloud/oidc.config.php
+++ b/tests/docker/owncloud/oidc.config.php
@@ -6,6 +6,5 @@ $CONFIG = [
 		'client-secret' => 'ownCloud',
 		'search-attribute' => 'sub',
 		'mode' => 'userid',
-		'use-token-introspection-endpoint' => false,
 	],
 ];

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -22,6 +22,8 @@
 
 namespace OCA\OpenIdConnect\Tests\Unit;
 
+use JsonException;
+use Jumbojett\OpenIDConnectClientException;
 use OCA\OpenIdConnect\Client;
 use OCP\IConfig;
 use OCP\ISession;
@@ -76,7 +78,7 @@ class ClientTest extends TestCase {
 
 		$this->client = $this->getMockBuilder(Client::class)
 			->setConstructorArgs([$this->config, $this->urlGenerator, $this->session, $this->logger])
-			->setMethods(['fetchURL'])
+			->onlyMethods(['fetchURL'])
 			->getMock();
 	}
 
@@ -91,7 +93,7 @@ class ClientTest extends TestCase {
 	 */
 	public function testGetAppConfig($expectedData, $dataInConfig, $expectedErrorMessage = null): void {
 		$this->config->method('getSystemValue')->willReturn('from system config');
-		$this->config->expects(self::once())->method('getAppValue')->willReturnCallback(function ($app, $key, $default) use ($dataInConfig) {
+		$this->config->expects(self::once())->method('getAppValue')->willReturnCallback(function () use ($dataInConfig) {
 			return $dataInConfig;
 		});
 		if ($expectedErrorMessage) {
@@ -101,6 +103,10 @@ class ClientTest extends TestCase {
 		self::assertEquals($expectedData, $return);
 	}
 
+	/**
+	 * @throws OpenIDConnectClientException
+	 * @throws JsonException
+	 */
 	public function testGetWellKnown(): void {
 		$this->client->setProviderURL('https://example.net');
 		$this->client->expects(self::once())->method('fetchURL')->with('https://example.net/.well-known/openid-configuration')->willReturn('{"foo": "bar"}');
@@ -108,6 +114,9 @@ class ClientTest extends TestCase {
 		self::assertEquals((object)['foo' => 'bar'], $return);
 	}
 
+	/**
+	 * @throws OpenIDConnectClientException
+	 */
 	public function testCtor(): void {
 		$providerUrl = 'https://example.net';
 
@@ -132,7 +141,7 @@ class ClientTest extends TestCase {
 		});
 		$this->client = $this->getMockBuilder(Client::class)
 			->setConstructorArgs([$this->config, $this->urlGenerator, $this->session, $this->logger])
-			->setMethods(['fetchURL'])
+			->onlyMethods(['fetchURL'])
 			->getMock();
 
 		self::assertEquals($providerUrl, $this->client->getProviderURL());
@@ -140,6 +149,9 @@ class ClientTest extends TestCase {
 		self::assertEquals(true, $this->client->getVerifyPeer());
 	}
 
+	/**
+	 * @throws OpenIDConnectClientException
+	 */
 	public function testCtorInsecure(): void {
 		$providerUrl = 'https://example.net';
 
@@ -165,7 +177,7 @@ class ClientTest extends TestCase {
 		});
 		$this->client = $this->getMockBuilder(Client::class)
 			->setConstructorArgs([$this->config, $this->urlGenerator, $this->session, $this->logger])
-			->setMethods(['fetchURL'])
+			->onlyMethods(['fetchURL'])
 			->getMock();
 
 		self::assertEquals($providerUrl, $this->client->getProviderURL());
@@ -176,15 +188,16 @@ class ClientTest extends TestCase {
 	/**
 	 * @dataProvider providesGetUserInfoData
 	 * @param $useAccessTokenPayloadForUserInfo
+	 * @throws JsonException
+	 * @throws OpenIDConnectClientException
 	 */
 	public function testGetUserInfo($useAccessTokenPayloadForUserInfo): void {
-		$this->config->method('getSystemValue')->willReturnCallback(static function ($key) use ($useAccessTokenPayloadForUserInfo) {
+		$this->config->method('getSystemValue')->willReturnCallback(static function ($key) {
 			if ($key === 'openid-connect') {
 				return [
 					'provider-url' => '$providerUrl',
 					'client-id' => 'client-id',
 					'client-secret' => 'secret',
-					'use-access-token-payload-for-user-info' => $useAccessTokenPayloadForUserInfo
 				];
 			}
 			if ($key === 'proxy') {
@@ -202,18 +215,18 @@ class ClientTest extends TestCase {
 			->getMock();
 		if ($useAccessTokenPayloadForUserInfo) {
 			$this->client->expects(self::never())->method('requestUserInfo');
-			$this->client->expects(self::once())->method('getAccessTokenPayload')->willReturn([
+			$this->client->expects(self::once())->method('getAccessTokenPayload')->willReturn((object)[
 				'preferred_username' => 'alice@example.net'
 			]);
 		} else {
-			$this->client->expects(self::never())->method('getAccessTokenPayload');
-			$this->client->expects(self::once())->method('requestUserInfo')->willReturn([
+			$this->client->expects(self::once())->method('getAccessTokenPayload')->willReturn(null);
+			$this->client->expects(self::once())->method('requestUserInfo')->willReturn((object)[
 				'preferred_username' => 'alice@example.net'
 			]);
 		}
 
 		$info = $this->client->getUserInfo();
-		self::assertEquals([
+		self::assertEquals((object)[
 			'preferred_username' => 'alice@example.net'
 		], $info);
 	}

--- a/tests/unit/EventHandlerTest.php
+++ b/tests/unit/EventHandlerTest.php
@@ -37,36 +37,24 @@ use Test\TestCase;
 class EventHandlerTest extends TestCase {
 
 	/**
-	 * @var MockObject | ISession
-	 */
-	private $session;
-	/**
 	 * @var MockObject | EventHandler
 	 */
 	private $eventHandler;
 	/**
-	 * @var MockObject | IUserSession
-	 */
-	private $userSession;
-	/**
 	 * @var MockObject | EventDispatcherInterface
 	 */
 	private $dispatcher;
-	/**
-	 * @var MockObject | IRequest
-	 */
-	private $request;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->dispatcher = $this->createMock(EventDispatcherInterface::class);
-		$this->request = $this->createMock(IRequest::class);
-		$this->session = $this->createMock(ISession::class);
-		$this->userSession = $this->createMock(IUserSession::class);
+		$request = $this->createMock(IRequest::class);
+		$session = $this->createMock(ISession::class);
+		$userSession = $this->createMock(IUserSession::class);
 
 		$this->eventHandler = $this->getMockBuilder(EventHandler::class)
-			->setConstructorArgs([$this->dispatcher, $this->request, $this->userSession, $this->session])
-			->setMethods(['createAuthBackend'])
+			->setConstructorArgs([$this->dispatcher, $request, $userSession, $session])
+			->onlyMethods(['createAuthBackend'])
 			->getMock();
 	}
 

--- a/tests/unit/LoggerTest.php
+++ b/tests/unit/LoggerTest.php
@@ -22,6 +22,7 @@
 
 namespace OCA\OpenIdConnect\Tests\Unit;
 
+use InvalidArgumentException;
 use OCA\OpenIdConnect\Logger;
 use OCP\ILogger;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -71,7 +72,7 @@ class LoggerTest extends TestCase {
 	}
 
 	public function testLogException(): void {
-		$ex = new \InvalidArgumentException();
+		$ex = new InvalidArgumentException();
 		$this->innerLogger->expects(self::once())->method('logException')->with($ex, ['app' => 'OpenID']);
 		$this->logger->logException($ex);
 	}


### PR DESCRIPTION
## Description
Whenever the given token is a JWT we try to use it for:
- user information
- expiry
- verification

## Motivation and Context
In some scenarios non JWT and JWT tokens can be used in parallel. We support this now.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
