### PR TITLE
fix: user information is only read from the JWT token if configured a…

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -219,8 +219,10 @@ class Client extends OpenIDConnectClient {
 	 */
 	public function getUserInfo() {
 		$openIdConfig = $this->getOpenIdConfig();
-		if ($payload = $this->getAccessTokenPayload()) {
-			return $payload;
+		if (isset($openIdConfig['use-access-token-payload-for-user-info']) && $openIdConfig['use-access-token-payload-for-user-info']) {
+			if ($payload = $this->getAccessTokenPayload()) {
+				return $payload;
+			}
 		}
 
 		if (isset($openIdConfig['use-access-token-introspection-for-user-info']) && $openIdConfig['use-access-token-introspection-for-user-info']) {

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -192,12 +192,13 @@ class ClientTest extends TestCase {
 	 * @throws OpenIDConnectClientException
 	 */
 	public function testGetUserInfo($useAccessTokenPayloadForUserInfo): void {
-		$this->config->method('getSystemValue')->willReturnCallback(static function ($key) {
+		$this->config->method('getSystemValue')->willReturnCallback(static function ($key) use ($useAccessTokenPayloadForUserInfo) {
 			if ($key === 'openid-connect') {
 				return [
 					'provider-url' => '$providerUrl',
 					'client-id' => 'client-id',
 					'client-secret' => 'secret',
+					'use-access-token-payload-for-user-info' => $useAccessTokenPayloadForUserInfo
 				];
 			}
 			if ($key === 'proxy') {
@@ -219,7 +220,7 @@ class ClientTest extends TestCase {
 				'preferred_username' => 'alice@example.net'
 			]);
 		} else {
-			$this->client->expects(self::once())->method('getAccessTokenPayload')->willReturn(null);
+			$this->client->expects(self::never())->method('getAccessTokenPayload');
 			$this->client->expects(self::once())->method('requestUserInfo')->willReturn((object)[
 				'preferred_username' => 'alice@example.net'
 			]);


### PR DESCRIPTION
…s such

## Description
User info can be retrieved from the user info endpoint, token introspection endpoint of from the the jwt token
In some deployment scenarios in is necessary to NOT read the user information from the JWT token but rely on user info endpoint.

For this scenario we brought back the config option 'use-access-token-payload-for-user-info' to explicitly enable if the info shall be read from the token

## Related Issue
- Fixes #248 

## How Has This Been Tested?
On test env - refs #248 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
