### PR TITLE
fix: header WWW-Authenticate must return Bearer to allow clients to c…

### DIFF
--- a/lib/Sabre/OpenIdSabreAuthBackend.php
+++ b/lib/Sabre/OpenIdSabreAuthBackend.php
@@ -177,7 +177,8 @@ class OpenIdSabreAuthBackend implements BackendInterface {
 		$defaults = new \OC_Defaults();
 		$realm = $defaults->getName();
 
-		$response->addHeader('WWW-Authenticate', 'Bearer/PoP realm="'.$realm.'"');
+		$response->addHeader('WWW-Authenticate', 'Bearer realm="'.$realm.'"');
+		$response->addHeader('WWW-Authenticate', 'PoP realm="'.$realm.'"');
 		$response->setStatus(401);
 	}
 


### PR DESCRIPTION
…onnect via OpenID Connect

## Description
WWW-Autenticate: Bearer/PoP is not recognized by the clients

## How Has This Been Tested?
- to be tested by qa

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
