### PR TITLE
Add config option to allow basic auth only for guests

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -30,7 +30,7 @@ More information on setup, configuration and migration can be found in the ownCl
     <repository type="git">https://github.com/owncloud/openidconnect.git</repository>
     <screenshot>https://raw.githubusercontent.com/owncloud/screenshots/master/openidconnect/openidconnect.png</screenshot>
     <dependencies>
-        <owncloud min-version="10" max-version="10"/>
+        <owncloud min-version="10.4" max-version="10"/>
         <php min-version="7.3" />
     </dependencies>
     <types>

--- a/lib/Application.php
+++ b/lib/Application.php
@@ -26,6 +26,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 use Jumbojett\OpenIDConnectClientException;
 use OC;
 use OC\HintException;
+use OCA\OpenIdConnect\LoginChecker;
 use OCP\AppFramework\App;
 
 class Application extends App {
@@ -68,13 +69,15 @@ class Application extends App {
 		$userSession = $server->getUserSession();
 		$urlGenerator = $server->getURLGenerator();
 		$request = $server->getRequest();
+		$loginChecker = $this->getContainer()->query(LoginChecker::class);
 		$loginPage = new LoginPageBehaviour($this->logger, $userSession, $urlGenerator, $request);
 		$loginPage->handleLoginPageBehaviour($openIdConfig);
 
 		// Add event listener
 		$dispatcher = $server->getEventDispatcher();
-		$eventHandler = new EventHandler($dispatcher, $request, $userSession, $session);
+		$eventHandler = new EventHandler($dispatcher, $request, $userSession, $session, $loginChecker);
 		$eventHandler->registerEventHandler();
+		$eventHandler->registerLoginHook();
 
 		// verify the session
 		$sessionVerifier = new SessionVerifier($this->logger, $session, $userSession, $memCacheFactory, $dispatcher, $client);

--- a/lib/Application.php
+++ b/lib/Application.php
@@ -69,7 +69,9 @@ class Application extends App {
 		$userSession = $server->getUserSession();
 		$urlGenerator = $server->getURLGenerator();
 		$request = $server->getRequest();
+		$config = $server->getConfig();
 		$loginChecker = $this->getContainer()->query(LoginChecker::class);
+
 		$loginPage = new LoginPageBehaviour($this->logger, $userSession, $urlGenerator, $request);
 		$loginPage->handleLoginPageBehaviour($openIdConfig);
 
@@ -77,7 +79,10 @@ class Application extends App {
 		$dispatcher = $server->getEventDispatcher();
 		$eventHandler = new EventHandler($dispatcher, $request, $userSession, $session, $loginChecker);
 		$eventHandler->registerEventHandler();
-		$eventHandler->registerLoginHook();
+		if ($config->getSystemValue('openid-connect.basic_auth_guest_only', false)) {
+			// the login hook is currently used only for this feature
+			$eventHandler->registerLoginHook();
+		}
 
 		// verify the session
 		$sessionVerifier = new SessionVerifier($this->logger, $session, $userSession, $memCacheFactory, $dispatcher, $client);

--- a/lib/LoginChecker.php
+++ b/lib/LoginChecker.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @author Juan Pablo Villafañez Ramos <jvillafanez@owncloud.com>
+ *
+ * @copyright Copyright (c) 2022, ownCloud GmbH
+ * @license GPL-2.0
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\OpenIdConnect;
+
+use OCP\IConfig;
+use OCP\IL10N;
+use OC\Helper\UserTypeHelper;
+use OC\User\LoginException;
+
+class LoginChecker {
+	/** @var IConfig */
+	private $config;
+	/** @var UserTypeHelper */
+	private $userTypeHelper;
+	/** @var IL10N*/
+	private $l10n;
+
+	public function __construct(IConfig $config, UserTypeHelper $userTypeHelper, IL10N $l10n) {
+		$this->config = $config;
+		$this->userTypeHelper = $userTypeHelper;
+		$this->l10n = $l10n;
+	}
+
+	/**
+	 * @param string $uid the uid to check if it's a guest or not
+	 * @throws LoginException if the uid isn't a guest
+	 */
+	public function ensurePasswordLoginJustForGuest($loginType, $uid) {
+		if (!$this->config->getSystemValue('openid-connect.basic_auth_guest_only', false)) {
+			return;
+		}
+
+		if (!$this->userTypeHelper->isGuestUser($uid) && $loginType === 'password') {
+			throw new LoginException($this->l10n->t('Only guests are allowed through this authentication mechanism'));
+		}
+	}
+}

--- a/lib/LoginChecker.php
+++ b/lib/LoginChecker.php
@@ -21,21 +21,17 @@
  */
 namespace OCA\OpenIdConnect;
 
-use OCP\IConfig;
 use OCP\IL10N;
 use OC\Helper\UserTypeHelper;
 use OC\User\LoginException;
 
 class LoginChecker {
-	/** @var IConfig */
-	private $config;
 	/** @var UserTypeHelper */
 	private $userTypeHelper;
 	/** @var IL10N*/
 	private $l10n;
 
-	public function __construct(IConfig $config, UserTypeHelper $userTypeHelper, IL10N $l10n) {
-		$this->config = $config;
+	public function __construct(UserTypeHelper $userTypeHelper, IL10N $l10n) {
 		$this->userTypeHelper = $userTypeHelper;
 		$this->l10n = $l10n;
 	}
@@ -45,10 +41,6 @@ class LoginChecker {
 	 * @throws LoginException if the uid isn't a guest
 	 */
 	public function ensurePasswordLoginJustForGuest($loginType, $uid) {
-		if (!$this->config->getSystemValue('openid-connect.basic_auth_guest_only', false)) {
-			return;
-		}
-
 		if (!$this->userTypeHelper->isGuestUser($uid) && $loginType === 'password') {
 			throw new LoginException($this->l10n->t('Only guests are allowed through this authentication mechanism'));
 		}

--- a/tests/unit/EventHandlerTest.php
+++ b/tests/unit/EventHandlerTest.php
@@ -23,14 +23,17 @@
 namespace OCA\OpenIdConnect\Tests\Unit;
 
 use OCA\OpenIdConnect\EventHandler;
+use OCA\OpenIdConnect\LoginChecker;
 use OCP\IRequest;
 use OCP\ISession;
+use OCP\IUser;
 use OCP\IUserSession;
 use OCP\SabrePluginEvent;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\Auth\Plugin;
 use Sabre\DAV\Server;
 use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\TestCase;
 
@@ -44,6 +47,8 @@ class EventHandlerTest extends TestCase {
 	 * @var MockObject | EventDispatcherInterface
 	 */
 	private $dispatcher;
+	/** @var LoginChecker */
+	private $loginChecker;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -51,9 +56,10 @@ class EventHandlerTest extends TestCase {
 		$request = $this->createMock(IRequest::class);
 		$session = $this->createMock(ISession::class);
 		$userSession = $this->createMock(IUserSession::class);
+		$this->loginChecker = $this->createMock(LoginChecker::class);
 
 		$this->eventHandler = $this->getMockBuilder(EventHandler::class)
-			->setConstructorArgs([$this->dispatcher, $request, $userSession, $session])
+			->setConstructorArgs([$this->dispatcher, $request, $userSession, $session, $this->loginChecker])
 			->onlyMethods(['createAuthBackend'])
 			->getMock();
 	}
@@ -93,5 +99,33 @@ class EventHandlerTest extends TestCase {
 		});
 		$this->eventHandler->expects(self::once())->method('createAuthBackend');
 		$this->eventHandler->registerEventHandler();
+	}
+
+	public function testAfterLoginHook(): void {
+		$this->loginChecker->expects($this->once())
+			->method('ensurePasswordLoginJustForGuest')
+			->with('customLoginType', 'myUid');
+
+		$user = $this->createMock(IUser::class);
+		$event = new GenericEvent(null, ['loginType' => 'customLoginType', 'user' => $user, 'uid' => 'myUid', 'password' => 'mypassword']);
+
+		$this->dispatcher->method('addListener')->willReturnCallback(static function ($name, $callback) use ($event) {
+			$callback($event);
+		});
+		$this->eventHandler->registerLoginHook();
+	}
+
+	public function testAfterLoginHookNoLoginType(): void {
+		$this->loginChecker->expects($this->once())
+			->method('ensurePasswordLoginJustForGuest')
+			->with(null, 'myUid');
+
+		$user = $this->createMock(IUser::class);
+		$event = new GenericEvent(null, ['user' => $user, 'uid' => 'myUid', 'password' => 'mypassword']);
+
+		$this->dispatcher->method('addListener')->willReturnCallback(static function ($name, $callback) use ($event) {
+			$callback($event);
+		});
+		$this->eventHandler->registerLoginHook();
 	}
 }

--- a/tests/unit/LoginCheckerTest.php
+++ b/tests/unit/LoginCheckerTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @author Juan Pablo Villafañez Ramos <jvillafanez@owncloud.com>
+ *
+ * @copyright Copyright (c) 2022, ownCloud GmbH
+ * @license GPL-2.0
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\OpenIdConnect\Tests\Unit;
+
+use OCA\OpenIdConnect\LoginChecker;
+use OCP\IL10N;
+use OC\Helper\UserTypeHelper;
+use OC\User\LoginException;
+use Test\TestCase;
+
+class LoginCheckerTest extends TestCase {
+	/** @var UserTypeHelper */
+	private $userTypeHelper;
+	/** @var IL10N */
+	private $l10n;
+	/** @var LoginChecker */
+	private $loginChecker;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->userTypeHelper = $this->createMock(UserTypeHelper::class);
+		$this->l10n = $this->createMock(IL10N::class);
+
+		$this->loginChecker = new LoginChecker($this->userTypeHelper, $this->l10n);
+	}
+
+	public function ensurePasswordLoginJustForGuestDataProvider() {
+		return [
+			[true, 'password'],
+			[true, 'token'],
+			[true, 'apache'],
+			[true, null],
+			[false, 'token'],
+			[false, 'apache'],
+			[false, 'null'],
+		];
+	}
+
+	/**
+	 * @dataProvider ensurePasswordLoginJustForGuestDataProvider
+	 */
+	public function testEnsurePasswordLoginJustForGuest($isGuest, $loginType) {
+		$this->userTypeHelper->expects($this->once())
+			->method('isGuestUser')
+			->willReturn($isGuest);
+		$this->assertNull($this->loginChecker->ensurePasswordLoginJustForGuest($loginType, 'myUser'));
+	}
+
+	public function testEnsurePasswordLoginJustForGuestNotGuest() {
+		$this->expectException(LoginException::class);
+
+		$this->userTypeHelper->method('isGuestUser')->willReturn(false);
+		$this->loginChecker->ensurePasswordLoginJustForGuest('password', 'muUser');
+	}
+}


### PR DESCRIPTION
Guests will be able to access ownCloud using basic auth, but other users will need to access through other mechanisms such as oidc.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for OpenId Connect App. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The new `openid-connect.basic_auth_guest_only` config option only allows guests to be able to log in using basic auth. Other users will need to use another auth mechanisms (such as oidc)

Note that the users can still log in with ANY OTHER auth mechanism available, not just oidc. It's expected that oidc is the only alternative though.

**NOTE**: minimum OC version raised to 10.4 in order to use the `UserTypeHelper` to detect guest users.

**To be checked**:
* remember me feature doesn't work with this app. It might still be useful for the guests though. We might need to disable the feature from the app info.
* App password aren't expected to work

## Related Issue
https://github.com/owncloud/enterprise/issues/5295

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested:
1. Setup:
    * Keycloak with LDAP connected
    * Guest app installed
    * user_ldap app installed and connected to the same server which keycloak is connected to.
    * openidconnect app connected to keycloak
2. Set `'openid-connect.basic_auth_guest_only' => true` in the config.php file
3. Ensure you can access with userA through keycloak using openidconnect (using the alternative login in the login page)
4. Ensure you can access with a guest user using username and password in the ownCloud's login page
5. Ensure you cannot access with userA through the ownCloud's login page

![Screenshot from 2022-09-26 14-06-15](https://user-images.githubusercontent.com/1477829/192272150-89a228a5-f99a-41df-9302-25c817fde3a5.png)

**Note**: Users (except guests) MUST also use a different auth mechanism (such as oidc) in order to access to the webdav interface. This might affect mobile and desktop clients. It's expected to work, but not tested yet.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] Unit tests
