### PR TITLE
feat: use password policy app to generate password for provisioned users

### DIFF
--- a/tests/unit/OpenIdConnectAuthModuleTest.php
+++ b/tests/unit/OpenIdConnectAuthModuleTest.php
@@ -229,7 +229,8 @@ class OpenIdConnectAuthModuleTest extends TestCase {
 		$this->lookupService->expects(self::once())->method('lookupUser')->willReturn($user);
 		$request = $this->createMock(IRequest::class);
 		$request->method('getHeader')->willReturn('Bearer 1234567890');
-		$this->autoProvisioningService->expects(self::once())->method('updateAccountInfo')->with($user, $userInfo)->willReturn(null);
+		$this->autoProvisioningService->expects(self::once())->method('updateAccountInfo')->with($user, $userInfo)->willReturnCallback(function () {
+		});
 		$this->authModule->auth($request);
 	}
 }


### PR DESCRIPTION
## Description
Generate password via password policy app if this app is enabled.

## Related Issue
- Fixes https://github.com/owncloud/openidconnect/issues/270

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
