### PR TITLE
chore: remove unused config option `use-token-introspection-endpoint`

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ $CONFIG = [
 - provider-params - additional config depending on the IdP is to be entered here - usually only necessary if the IdP does not support service discovery
 - auth-params - additional parameters which are sent to the IdP during the auth requests
 - redirect-url - the full url under which the ownCloud OpenId Connect redirect url is reachable - only needed in special setups
-- use-token-introspection-endpoint - if set to true the token introspection endpoint is used to verify a given access token - only needed if the access token is not a JWT
 - token-introspection-endpoint-client-id & token-introspection-endpoint-client-secret - client id and secret to be used with the token introspection endpoint
 - post_logout_redirect_uri - a given url where the IdP should redirect to after logout
 - mode - the mode to search for user in ownCloud - either userid or email
@@ -225,7 +224,6 @@ To set it up locally do the following:
          'loginButtonName' => 'node-oidc-provider',
          'mode' => 'userid',
          'search-attribute' => 'sub',
-         'use-token-introspection-endpoint' => true,
          // do not verify tls host or peer
          'insecure' => true
      ],

--- a/tests/unit/OpenIdConnectAuthModuleTest.php
+++ b/tests/unit/OpenIdConnectAuthModuleTest.php
@@ -135,7 +135,7 @@ class OpenIdConnectAuthModuleTest extends TestCase {
 	 * @throws LoginException
 	 */
 	public function testInvalidTokenWithIntrospection(): void {
-		$this->client->method('getOpenIdConfig')->willReturn(['use-token-introspection-endpoint' => true]);
+		$this->client->method('getOpenIdConfig')->willReturn([]);
 		$this->client->method('introspectToken')->willReturn((object)['error' => 'expired']);
 		$this->cacheFactory->method('create')->willReturn(new ArrayCache());
 		$request = $this->createMock(IRequest::class);
@@ -150,7 +150,7 @@ class OpenIdConnectAuthModuleTest extends TestCase {
 	 * @throws LoginException
 	 */
 	public function testInvalidTokenWithIntrospectionNotActive(): void {
-		$this->client->method('getOpenIdConfig')->willReturn(['use-token-introspection-endpoint' => true]);
+		$this->client->method('getOpenIdConfig')->willReturn([]);
 		$this->client->method('introspectToken')->willReturn((object)['active' => false]);
 		$this->cacheFactory->method('create')->willReturn(new ArrayCache());
 		$request = $this->createMock(IRequest::class);
@@ -165,7 +165,7 @@ class OpenIdConnectAuthModuleTest extends TestCase {
 	 * @throws LoginException
 	 */
 	public function testValidTokenWithIntrospection(): void {
-		$this->client->method('getOpenIdConfig')->willReturn(['use-token-introspection-endpoint' => true]);
+		$this->client->method('getOpenIdConfig')->willReturn([]);
 		$this->client->method('introspectToken')->willReturn((object)['active' => true, 'exp' => \time() + 3600]);
 		$this->client->method('getUserInfo')->willReturn((object)['email' => 'foo@example.com']);
 		$this->cacheFactory->method('create')->willReturn(new ArrayCache());
@@ -182,7 +182,7 @@ class OpenIdConnectAuthModuleTest extends TestCase {
 	 * @throws LoginException
 	 */
 	public function testValidTokenWithJWT(): void {
-		$this->client->method('getOpenIdConfig')->willReturn(['use-token-introspection-endpoint' => false]);
+		$this->client->method('getOpenIdConfig')->willReturn([]);
 		$this->client->method('verifyJWTsignature')->willReturn(true);
 		$this->client->method('getAccessTokenPayload')->willReturn((object)['exp' => \time() + 3600]);
 		$this->client->method('getUserInfo')->willReturn((object)['email' => 'foo@example.com']);


### PR DESCRIPTION
## Description
The config option `use-token-introspection-endpoint` is no longer used and therefore removed.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
