### PR TITLE
[tests-only] Remove unused use-token-introspection-endpoint in test

### DIFF
--- a/tests/unit/SessionVerifierTest.php
+++ b/tests/unit/SessionVerifierTest.php
@@ -233,7 +233,6 @@ class SessionVerifierTest extends TestCase {
 		$cache = $this->createMock(ICache::class);
 		$this->cacheFactory->expects(self::exactly(2))->method('create')->with('oca.openid-connect')->willReturn($cache);
 		$exp = \time() + 3600;
-		$this->client->method('getOpenIdConfig')->willReturn(['use-token-introspection-endpoint' => true]);
 		$this->client->method('introspectToken')->willReturn((object)['active' => true, 'exp' => $exp]);
 
 		$cache->expects(self::once())->method('set')->with('access-123456', $exp);


### PR DESCRIPTION
## Description
Documentation of this unused config setting was removed in core PR https://github.com/owncloud/core/pull/40688

Remove the last mention from the tests.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
