### PR TITLE
[tests-only][full-ci]Remove github comment from drone CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -21,7 +21,6 @@ PLUGINS_SLACK = "plugins/slack:1"
 SELENIUM_STANDALONE_CHROME_DEBUG = "selenium/standalone-chrome-debug:3.141.59-oxygen"
 SELENIUM_STANDALONE_FIREFOX_DEBUG = "selenium/standalone-firefox-debug:3.8.1"
 SONARSOURCE_SONAR_SCANNER_CLI = "sonarsource/sonar-scanner-cli"
-THEGEEKLAB_DRONE_GITHUB_COMMENT = "thegeeklab/drone-github-comment:1"
 
 DEFAULT_PHP_VERSION = "7.4"
 DEFAULT_NODEJS_VERSION = "14"
@@ -911,7 +910,6 @@ def acceptance(ctx):
         "skip": False,
         "debugSuites": [],
         "skipExceptParts": [],
-        "earlyFail": True,
         "enableApp": True,
         "selUserNeeded": False,
     }
@@ -948,14 +946,6 @@ def acceptance(ctx):
 
             if params["skip"]:
                 continue
-
-            # switch off earlyFail if the PR title contains full-ci
-            if ("full-ci" in ctx.build.title.lower()):
-                params["earlyFail"] = False
-
-            # switch off earlyFail when running cron builds (for example, nightly CI)
-            if (ctx.build.event == "cron"):
-                params["earlyFail"] = False
 
             if "externalScality" in params and len(params["externalScality"]) != 0:
                 # We want to use an external scality server for this pipeline.
@@ -1168,7 +1158,7 @@ def acceptance(ctx):
                                          "path": "%s/downloads" % dir["server"],
                                      }],
                                  }),
-                             ] + testConfig["extraTeardown"] + githubComment(params["earlyFail"]),
+                             ] + testConfig["extraTeardown"],
                     "services": databaseService(testConfig["database"]) +
                                 browserService(testConfig["browser"]) +
                                 emailService(testConfig["emailNeeded"]) +
@@ -1994,33 +1984,6 @@ def buildTestConfig(params):
                             config["runPart"] = runPart
                             configs.append(config)
     return configs
-
-def githubComment(earlyFail):
-    if (earlyFail):
-        return [{
-            "name": "github-comment",
-            "image": THEGEEKLAB_DRONE_GITHUB_COMMENT,
-            "pull": "if-not-exists",
-            "settings": {
-                "message": ":boom: Acceptance tests pipeline <strong>${DRONE_STAGE_NAME}</strong> failed. The build has been cancelled.\\n\\n${DRONE_BUILD_LINK}/${DRONE_JOB_NUMBER}${DRONE_STAGE_NUMBER}",
-                "key": "pr-${DRONE_PULL_REQUEST}",
-                "update": "true",
-                "api_key": {
-                    "from_secret": "github_token",
-                },
-            },
-            "when": {
-                "status": [
-                    "failure",
-                ],
-                "event": [
-                    "pull_request",
-                ],
-            },
-        }]
-
-    else:
-        return []
 
 def checkStarlark():
     return [{


### PR DESCRIPTION
## Description
Last week we removed the drone code to stop previous PR builds, and to cancel a build early when a single pipeline fails.

The remaining special CI feature that we have is the drone code that posts a comment to GitHub about a failing acceptance test pipeline. That no longer works because it needs a GitHub token with too many permissions, and we do not make that available to PRs.

This PR removes the GitHub comment code from the drone CI. The `earlyFail` setting is also removed, because there is nothing that uses it any more

Part of: https://github.com/owncloud/QA/issues/820

> Note: This PR was made by an automated script, in case something is not right I'll take care of it manually. 