### PR TITLE
chore(deps): bump PHP dependencies

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -50,16 +50,16 @@
         },
         {
             "name": "paragonie/constant_time_encoding",
-            "version": "v2.6.3",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/constant_time_encoding.git",
-                "reference": "58c3f47f650c94ec05a151692652a868995d2938"
+                "reference": "52a0d99e69f56b9ec27ace92ba56897fe6993105"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/58c3f47f650c94ec05a151692652a868995d2938",
-                "reference": "58c3f47f650c94ec05a151692652a868995d2938",
+                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/52a0d99e69f56b9ec27ace92ba56897fe6993105",
+                "reference": "52a0d99e69f56b9ec27ace92ba56897fe6993105",
                 "shasum": ""
             },
             "require": {
@@ -113,7 +113,7 @@
                 "issues": "https://github.com/paragonie/constant_time_encoding/issues",
                 "source": "https://github.com/paragonie/constant_time_encoding"
             },
-            "time": "2022-06-14T06:56:20+00:00"
+            "time": "2024-05-08T12:18:48+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -167,20 +167,20 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.37",
+            "version": "3.0.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "cfa2013d0f68c062055180dd4328cc8b9d1f30b8"
+                "reference": "211ebc399c6e73c225a018435fe5ae209d1d1485"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/cfa2013d0f68c062055180dd4328cc8b9d1f30b8",
-                "reference": "cfa2013d0f68c062055180dd4328cc8b9d1f30b8",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/211ebc399c6e73c225a018435fe5ae209d1d1485",
+                "reference": "211ebc399c6e73c225a018435fe5ae209d1d1485",
                 "shasum": ""
             },
             "require": {
-                "paragonie/constant_time_encoding": "^1|^2",
+                "paragonie/constant_time_encoding": "^1|^2|^3",
                 "paragonie/random_compat": "^1.4|^2.0|^9.99.99",
                 "php": ">=5.6.1"
             },
@@ -257,7 +257,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.37"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.39"
             },
             "funding": [
                 {
@@ -273,7 +273,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-03T02:14:58+00:00"
+            "time": "2024-06-24T06:27:33+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
```
Updating dependencies
Lock file operations: 0 installs, 2 updates, 0 removals
  - Upgrading paragonie/constant_time_encoding (v2.6.3 => v2.7.0)
  - Upgrading phpseclib/phpseclib (3.0.37 => 3.0.39)
Writing lock file
```

This might help with the Trivy messages:
https://drone.owncloud.com/owncloud-docker/server/1772/2/6
```
var/www/owncloud/apps/openidconnect/vendor/composer/installed.json (composer-vendor)
====================================================================================
Total: 5 (HIGH: 5, CRITICAL: 0)

┌─────────────────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────────────┬─────────────────────────────────────────────────────────────┐
│       Library       │ Vulnerability  │ Severity │ Status │ Installed Version │     Fixed Version      │                            Title                            │
├─────────────────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────────────┼─────────────────────────────────────────────────────────────┤
│ phpseclib/phpseclib │ CVE-2023-27560 │ HIGH     │ fixed  │ 3.0.16            │ 3.0.19                 │ Math/PrimeField.php in phpseclib 3.x before 3.0.19 has an   │
│                     │                │          │        │                   │                        │ infinite loo ...                                            │
│                     │                │          │        │                   │                        │ https://avd.aquasec.com/nvd/cve-2023-27560                  │
│                     ├────────────────┤          │        │                   ├────────────────────────┼─────────────────────────────────────────────────────────────┤
│                     │ CVE-2023-49316 │          │        │                   │ 3.0.34                 │ In Math/BinaryField.php in phpseclib 3 before 3.0.34,       │
│                     │                │          │        │                   │                        │ excessively larg ...                                        │
│                     │                │          │        │                   │                        │ https://avd.aquasec.com/nvd/cve-2023-49316                  │
│                     ├────────────────┤          │        │                   ├────────────────────────┼─────────────────────────────────────────────────────────────┤
│                     │ CVE-2023-52892 │          │        │                   │ 1.0.22, 2.0.46, 3.0.33 │ In phpseclib before 1.0.22, 2.x before 2.0.46, and 3.x      │
│                     │                │          │        │                   │                        │ before 3.0.33, ...                                          │
│                     │                │          │        │                   │                        │ https://avd.aquasec.com/nvd/cve-2023-52892                  │
│                     ├────────────────┤          │        │                   ├────────────────────────┼─────────────────────────────────────────────────────────────┤
│                     │ CVE-2024-27354 │          │        │                   │ 3.0.36, 2.0.47, 1.0.23 │ An issue was discovered in phpseclib 1.x before 1.0.23, 2.x │
│                     │                │          │        │                   │                        │ before 2.0...                                               │
│                     │                │          │        │                   │                        │ https://avd.aquasec.com/nvd/cve-2024-27354                  │
│                     ├────────────────┤          │        │                   │                        ├─────────────────────────────────────────────────────────────┤
│                     │ CVE-2024-27355 │          │        │                   │                        │ An issue was discovered in phpseclib 1.x before 1.0.23, 2.x │
│                     │                │          │        │                   │                        │ before 2.0...                                               │
│                     │                │          │        │                   │                        │ https://avd.aquasec.com/nvd/cve-2024-27355                  │
└─────────────────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────────────┴─────────────────────────────────────────────────────────────┘
Exit Code 1
```

We don't strictly need these latest versions, but it would be nice to have them.

We do need a release that can be bundled with 10.15.0 that has more-recent PHP dependencies.