### PR TITLE
Fix: email not set when user logs in for the first time (#328)

### DIFF
--- a/lib/Service/AutoProvisioningService.php
+++ b/lib/Service/AutoProvisioningService.php
@@ -163,7 +163,7 @@ class AutoProvisioningService {
 			throw new LoginException('Account auto-update is disabled.');
 		}
 		# email is only changed in case the mode is not `email`
-		if ($this->client->mode() !== 'email') {
+		if ($force || $this->client->mode() !== 'email') {
 			if ($force || $user->canChangeMailAddress()) {
 				$currentEmail = $this->client->getUserEmail($userInfo);
 				if ($currentEmail && $currentEmail !== $user->getEMailAddress()) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for OpenId Connect App. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Set label "backport-request" if backport is needed
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Small change, adds `$force ||` to fix `AutoProvisioningService`, which is currently [broken](#motivation-and-context).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #328

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A change in `v2.3.1` made it so when `$this->client->mode() == 'email'`:
- `AutoProvisioningService->updateAccountInfo()` skips `$user->setEMailAddress($currentEmail)`
- `AutoProvisioningService->createUser()` calls `updateAccountInfo()` in order to hydrate it with the appropriate data.
- So you end up with:
  - A first-time user logs in.
  - `$user->setEMailAddress($currentEmail)` is skipped; the user is able to use the app.
  - The user logs out; logs back in.
  - The app tries to search for an existing email; finds none. Creates a new user.
- Despite the user seeing that they've successfully logged in, they are unaware that every time they do so, they are actually being binding to a brand new user than the one they were in their previous session. The tip off is that they find they can no longer see file that they themselves created, as said files technically belong to a "different" user.
- Furthermore, this results in a plethora of zombie user accounts

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on our client's `staging` environment.

### Reproducing the Issue
1. Logged in as `admin` in a primary private browser
2. Created a test user in our `staging` SSO.
3. Successfully Logged into `ownCloud` in a secondary private browser. Created a file.
4. As `admin`, observed the new user and display name.
5. Successfully Logged into `ownCloud` in a tertiary private browser. Cannot see the file I created.
6. As `admin`, observed two new users with the same display name.

### Testing the Fix
1. Deleted the previous zombie users.
2. Successfully Logged into `ownCloud` in a secondary private browser. Created a file.
3. As `admin`, observed the new user and display name.
4. Successfully Logged into `ownCloud` in a tertiary private browser. Can see the file I created.
5. As `admin`, observed no users newer than what was initially observed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes

