### PR TITLE
chore: update dependabot to weekly Sunday schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,29 @@
 version: 2
 updates:
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "22:00"
-  open-pull-requests-limit: 10
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: '22:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: '22:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
This PR adds/updates the Dependabot configuration for this repository.

Dependabot is configured to run weekly (Sunday at 22:00 UTC) with a limit of 5 open pull requests per ecosystem. Minor and patch updates are grouped into a single PR per ecosystem to reduce the number of concurrent update PRs, lowering maintainer overhead and CI load. Major version updates remain as individual PRs so they receive deliberate review.
