### PR TITLE
docs(ospo): community health rollout v2 — README, agents.md, health files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows the ownCloud Code of Conduct.
+
+Please read the full Code of Conduct at:
+**<https://owncloud.com/contribute/code-of-conduct/>**
+
+By participating in this project, you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Thank you for your interest in contributing to this project!
+
+Please read the full contributing guidelines at:
+**<https://owncloud.com/contribute/>**
+
+For development setup, coding standards, and pull request process,
+see the README in this repository.

--- a/README.md
+++ b/README.md
@@ -1,246 +1,129 @@
-# OpenId Connect for ownCloud
+# OpenID Connect
 
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=owncloud_openidconnect&metric=alert_status)](https://sonarcloud.io/dashboard?id=owncloud_openidconnect)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=owncloud_openidconnect&metric=security_rating)](https://sonarcloud.io/dashboard?id=owncloud_openidconnect)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=owncloud_openidconnect&metric=coverage)](https://sonarcloud.io/dashboard?id=owncloud_openidconnect)
+<!-- OSPO-managed README | Generated: 2026-04-16 | v2 -->
 
-## Configuration
+[![License](https://img.shields.io/badge/License-GPL--2.0-blue.svg)](LICENSE) [![ownCloud OSPO](https://img.shields.io/badge/OSPO-ownCloud-blue)](https://kiteworks.com/opensource) [![Docker Hub](https://img.shields.io/docker/pulls/owncloud)](https://hub.docker.com/r/owncloud/server)
 
-### General
+An ownCloud Server app that enables OpenID Connect (OIDC) authentication, allowing users to log in through an external identity provider. It supports multiple identity providers via database-stored configuration, automatic user provisioning, token-based session management, and flexible login button customization.
 
-A distributed memcache setup is required to properly operate this app - like Redis or memcached.
-For development purpose APCu is reasonable as well.
-Please follow the [documentation on how to set up caching](https://doc.owncloud.com/server/admin_manual/configuration/server/caching_configuration.html#supported-caching-backends).
+## Getting Started
 
-### Setup
+Follow the steps below to install and configure the OpenID Connect app.
 
-The OpenId integration is established by either entering the parameters below to the
-ownCloud configuration file or saving them to the app config database table.
+### Prerequisites
 
-_provider-url_, _client-id_ and _client-secret- are to be taken from the OpenId
-Provider setup.
-_loginButtonName_ can be chosen freely depending on the installation.
+- ownCloud Server 10.x
+- PHP 7.4+
+- Distributed memcache (Redis recommended)
+- An OpenID Connect provider
 
-### Settings in database
+### Installation
 
-If you run a clustered setup, the following method is preferred because it is stateless. The OpenID Connect app checks for settings in the database first. If none is found, it falls back to the settings stored in `config.php`. If a malformed JSON string is found, an error is logged. You have to store your settings as a JSON formatted string in the ownCloud database table `oc_appconfig` with the following keys:
-
-| Key         | Value            |
-| ----------- | ---------------- |
-| appid       | 'openidconnect'  |
-| configkey   | 'openid-connect' |
-| configvalue | _JSON-String_    |
-
-The _key->value_ pairs are the same as when storing them to the `config.php` file. The preferred method is using the occ command:
-
+```bash
+occ app:enable openidconnect
 ```
+
+### Configuration
+
+Configure via `occ` command:
+
+```bash
 occ config:app:set openidconnect openid-connect \
---value='{"provider-url":"https://idp.example.net","client-id":"fc9b5c78-ec73-47bf-befc-59d4fe780f6f","client-secret":"e3e5b04a-3c3c-4f4d-b16c-2a6e9fdd3cd1","loginButtonName":"Login via OpenId Connect"}'
+  --value='{"provider-url":"https://idp.example.net","client-id":"your-client-id","client-secret":"your-secret","loginButtonName":"Login via OpenId Connect"}'
 ```
 
-This task can also be done by opening the database console for your ownCloud database and enter the following example command. Use the database commands `UPDATE` or `DELETE` to change or delete this keys (not recommended).
+### Run Tests
 
-```
-INSERT INTO oc_appconfig (
-  appid,
-  configkey,
-  configvalue
-) VALUES (
-  'openidconnect',
-  'openid-connect',
-  '{"provider-url":"https://idp.example.net","client-id":"fc9b5c78-ec73-47bf-befc-59d4fe780f6f","client-secret":"e3e5b04a-3c3c-4f4d-b16c-2a6e9fdd3cd1","loginButtonName":"Login via OpenId Connect"}'
-);
+```bash
+make test-php-unit
+make test-php-style
 ```
 
-Note: The app checks for settings in the database first. If none is found it falls back to the config.php. If a malformed JSON string is found an error is thrown to the logger instance.
+## Documentation
 
-### Settings in config.php
+- [ownCloud OIDC Documentation](https://doc.owncloud.com/server/latest/admin_manual/)
+- [OpenID Connect Specification](https://openid.net/connect/)
 
-```php
-<?php
-$CONFIG = [
-  'openid-connect' => [
-    'provider-url' => 'https://idp.example.net',
-    'client-id' => 'fc9b5c78-ec73-47bf-befc-59d4fe780f6f',
-    'client-secret' => 'e3e5b04a-3c3c-4f4d-b16c-2a6e9fdd3cd1',
-    'loginButtonName' => 'OpenId Connect',
-  ],
-];
-```
+## Part of ownCloud Server (Classic)
 
-The above configuration assumes that the OpenId Provider is supporting service discovery.
-If not the endpoint configuration has to be done manually as follows:
+This app extends [ownCloud Server 10](https://github.com/owncloud/core) with OIDC support for single sign-on. It requires a distributed memcache backend (Redis, Memcached, or APCu for development).
 
-```php
-<?php
-$CONFIG = [
-  'openid-connect' => [
-    'provider-url' => 'https://idp.example.net',
-    'client-id' => 'fc9b5c78-ec73-47bf-befc-59d4fe780f6f',
-    'client-secret' => 'e3e5b04a-3c3c-4f4d-b16c-2a6e9fdd3cd1',
-    'loginButtonName' => 'OpenId Connect',
-    'post_logout_redirect_uri' => '...',
-    'provider-params' => [
-      'authorization_endpoint' => '...',
-      'token_endpoint' => '...',
-      'token_endpoint_auth_methods_supported' => '...',
-      'userinfo_endpoint' => '...',
-      'registration_endpoint' => '...',
-      'end_session_endpoint' => '...',
-      'jwks_uri' => '...',
-    ],
-  ],
-];
-```
+The ownCloud Server is available on [Docker Hub](https://hub.docker.com/r/owncloud/server).
 
-### Setup auto provisioning mode
+## Community & Support
 
-The auto provisioning mode will create a user based on the provided user information as returned by the OpenID Connect provider.
-The config parameters 'mode' and 'search-attribute' will be used to create a unique user so that the lookup mechanism can find the user again.
+**[Star](https://github.com/owncloud/openidconnect)** this repo and **Watch** for release notifications!
 
-```php
-<?php
-$CONFIG = [
-  'openid-connect' => [
-    'auto-provision' => [
-      // explicit enable the auto provisioning mode
-      'enabled' => true,
-      // documentation about standard claims: https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
-      // only relevant in userid mode,  defines the claim which holds the email of the user
-      'email-claim' => 'email',
-      // defines the claim which holds the display name of the user
-      'display-name-claim' => 'given_name',
-      // defines the claim which holds the picture of the user - must be a URL
-      'picture-claim' => 'picture',
-      // defines a list of groups to which the newly created user will be added automatically
-      'groups' => ['admin', 'guests', 'employees'],
-    ],
-  ],
-];
-```
+- [ownCloud Website](https://owncloud.com)
+- [Community Discussions](https://github.com/orgs/owncloud/discussions)
+- [Matrix Chat](https://app.element.io/#/room/#owncloud:matrix.org)
+- [Documentation](https://doc.owncloud.com)
+- [Enterprise Support](https://owncloud.com/contact-us/)
+- [OSPO Home](https://kiteworks.com/opensource)
 
-#### Setup auto-update of user account info
+## Contributing
 
-The provisioning auto-update mode will update user account info with current information provided by the OpenID Connect provider
-upon each log in.
+We welcome contributions! Please read the [Contributing Guidelines](CONTRIBUTING.md)
+and our [Code of Conduct](CODE_OF_CONDUCT.md) before getting started.
 
-```php
-$CONFIG = [
-  'openid-connect' => [
-    'auto-provision' => [
-      'update' => [
-        // enable the user info auto-update mode
-        'enabled' => true,
-      ],
-    ],
-  ],
-];
-```
+### Workflow
 
-#### All Configuration Values explained
+- **Rebase Early, Rebase Often!** We use a rebase workflow. Always rebase on the target branch before submitting a PR.
+- **Dependabot**: Automated dependency updates are managed via Dependabot. Review and merge dependency PRs promptly.
+- **Signed Commits**: All commits **must** be PGP/GPG signed. See [GitHub's signing guide](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+- **DCO Sign-off**: Every commit must carry a `Signed-off-by` line:
+  ```
+  git commit -s -S -m "your commit message"
+  ```
+- **GitHub Actions Policy**: Workflows may only use actions that are (a) owned by `owncloud`, (b) created by GitHub (`actions/*`), or (c) verified in the GitHub Marketplace.
 
-- loginButtonName - the name as displayed on the login screen which is used to redirect to the IdP
-- autoRedirectOnLoginPage - if set to true the login page will redirect to the Idp right away
-- provider-url - the url where the IdP is living. In some cases (KeyCloak, Azure AD) this holds more than just a domain but also a path
-- client-id & client-secret - self-explanatory
-- scopes - depending on the IdP setup, needs the list of required scopes to be entered here
-- insecure - boolean value (true/false), no ssl verification will take place when talking to the IdP - DON'T use in production
-- provider-params - additional config depending on the IdP is to be entered here - usually only necessary if the IdP does not support service discovery
-- auth-params - additional parameters which are sent to the IdP during the auth requests
-- redirect-url - the full url under which the ownCloud OpenId Connect redirect url is reachable - only needed in special setups
-- token-introspection-endpoint-client-id & token-introspection-endpoint-client-secret - client id and secret to be used with the token introspection endpoint
-- post_logout_redirect_uri - a given url where the IdP should redirect to after logout
-- mode - the mode to search for user in ownCloud - either userid or email
-- search-attribute - the attribute which is taken from the access token JWT or user info endpoint to identify the user
-- allowed-user-backends - limit the users which are allowed to login to a specific user backend - e.g. LDAP
-- use-access-token-payload-for-user-info - if set to true any user information will be read from the access token. If set to false the userinfo endpoint is used (starting app version 1.1.0)
-- jwt-self-signed-jwk-header-supported - if set to true JWK will be taken from the JWT header instead of the IdP's jwks_uri. Should only be enabled in exceptional cases as this could lead to vulnerabilities https://portswigger.net/kb/issues/00200902_jwt-self-signed-jwk-header-supported
+## Translations
 
-### Setup within the OpenId Provider
+Help translate this project on Transifex:
+**<https://explore.transifex.com/owncloud-org/owncloud/>**
 
-When registering ownCloud as OpenId Client use `https://cloud.example.net/index.php/apps/openidconnect/redirect` as redirect url .
+Please submit translations via Transifex -- do not open pull requests for translation changes.
 
-In case [OpenID Connect Front-Channel Logout 1.0](https://openid.net/specs/openid-connect-frontchannel-1_0.html)
-is supported please enter `https://cloud.example.net/index.php/apps/openidconnect/logout` as logout url within the client registration of the OpenId Provider.
-We require `frontchannel_logout_session_required` to be true.
+## Security
 
-### Setup service discovery
+**Do not open a public GitHub issue for security vulnerabilities.**
 
-In order to allow other clients to use OpenID Connect when talking to ownCloud please setup
-a redirect on the web server to point .well-known/openid-configuration to /index.php/apps/openidconnect/config
+Report vulnerabilities at **<https://security.owncloud.com>** -- see [SECURITY.md](SECURITY.md).
 
-This is an .htaccess example
+Bug bounty: [YesWeHack ownCloud Program](https://yeswehack.com/programs/owncloud-bug-bounty-program)
 
-```
-  RewriteRule ^\.well-known/openid-configuration /index.php/apps/openidconnect/config [P]
-```
+## License
 
-The Apache modules proxy and proxy_http need to be enabled. (Debian/Ubuntu: a2enmod proxy proxy_http)
+This project is licensed under the [GPL-2.0](LICENSE).
 
-### How to setup an IdP for development and test purpose
+## About the ownCloud OSPO
 
-There are various Open Source IdPs out there. The one with the most features implemented seems to be [panva/node-oidc-provider](https://github.com/panva/node-oidc-provider).
-CAUTION: node-oidc-provider does not accept the redirect URLs we need for owncloud clients. For release testing, use kopano konnectd instead.
+The [Kiteworks Open Source Program Office](https://kiteworks.com/opensource), operating under
+the [ownCloud](https://owncloud.com) brand, launched on May 5, 2026, to steward the open source
+ecosystem around ownCloud's products. The OSPO ensures transparent governance, license compliance,
+community health, and sustainable collaboration between the open source community and
+[Kiteworks](https://www.kiteworks.com), which acquired ownCloud in 2023.
 
-To set it up locally do the following:
+- **OSPO Home**: <https://kiteworks.com/opensource>
+- **GitHub**: <https://github.com/owncloud>
+- **ownCloud**: <https://owncloud.com>
 
-1. Clone panva/node-oidc-provider
-2. yarn install
-3. cd example
-4. Add client config into <https://github.com/panva/node-oidc-provider/blob/master/example/support/configuration.js#L14>
+For questions about the OSPO or licensing, contact ospo@kiteworks.com.
 
-   ```
-   module.exports.clients = [
-     {
-       client_id: 'ownCloud',
-       client_secret: 'ownCloud',
-       grant_types: ['refresh_token', 'authorization_code'],
-       redirect_uris: ['http://localhost:8080/index.php/apps/openidconnect/redirect'],
-       frontchannel_logout_uri: 'http://localhost:8080/index.php/apps/openidconnect/logout'
-     }
-   ];
+### License Migration to Apache 2.0
 
-   // Enable introspection
-   module.exports.features: {
-      devInteractions: { enabled: false },
-      introspection: { enabled: true },
-      deviceFlow: { enabled: true },
-      revocation: { enabled: true },
-      issAuthResp: { enabled: true },
-   },
+The OSPO is driving a strategic relicensing of ownCloud repositories toward the
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), following
+the [Apache Software Foundation's third-party license policy](https://www.apache.org/legal/resolved.html).
 
-   ```
+Individual repositories will migrate as their audit is completed. The LICENSE file
+in each repo reflects its **current** license status (not the target).
 
-5. Start the IdP via: `node standalone.js`
-6. Open in browser: <http://localhost:3000/.well-known/openid-configuration>
-7. ownCloud configuration looks as follows:
+**Current license: GPL-2.0** (Category X per Apache policy -- cannot be included in Apache-2.0 works).
 
-   ```
-   $CONFIG = [
-     'openid-connect' => [
-         'provider-url' => 'http://localhost:3000',
-         'client-id' => 'ownCloud',
-         'client-secret' => 'ownCloud',
-         'loginButtonName' => 'node-oidc-provider',
-         'mode' => 'userid',
-         'search-attribute' => 'sub',
-         // do not verify tls host or peer
-         'insecure' => true
-     ],
-   ];
+Migration prerequisites for this repository:
 
-   ```
-
-8. Clients can now use <http://localhost:3000/.well-known/openid-configuration> to obtain all information which is necessary
-   to initiate the OpenId Connect flow. Use the granted access token in any request to ownCloud within a bearer authentication header.
-9. You can login with any credentials but you need to make sure that the user with the given user id exists. In a real world deployment the users will come from LDAP.
--  Keep in mind that by default, oidc app will search for the `email` attribute - which is hardcoded to `johndoe@example.com` [ref](https://github.com/panva/node-oidc-provider/blob/master/example/support/account.js#L32)
--  If you wish to map the login name on the oidc-provider with owncloud user ids, you can configure it as following:
-
-```
-    $CONFIG = [
-      'openid-connect' => [
-        'search-attribute' => 'sub',
-        'mode' => 'userid',
-      ]
-```
+- **CLA/DCO coverage**: All past contributors must have signed agreements permitting relicensing
+- **Copyleft dependency audit**: All GPL dependencies must be replaced or isolated
+- **KDE heritage review**: Any code with KDE-era copyrights requires legal analysis
+- **Complete relicensing**: GPL-2.0 is a strong copyleft license; migration requires full relicensing of all files

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security issues responsibly via:
+**<https://security.owncloud.com>**
+
+You can also report vulnerabilities through our YesWeHack bug bounty program:
+**<https://yeswehack.com/programs/owncloud-bug-bounty-program>**

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,10 @@
+# Support
+
+For support with this project, please use the following channels:
+
+- **Enterprise Support**: <https://owncloud.com/contact-us/>
+- **Community discussions**: https://github.com/orgs/owncloud/discussions
+- **Matrix Chat**: <https://app.element.io/#/room/#owncloud:matrix.org>
+- **Documentation**: <https://doc.owncloud.com>
+
+Please do not use GitHub issues for general support questions.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,59 @@
+# agents.md -- OpenID Connect
+
+## Repository Overview
+
+ownCloud Server app enabling OpenID Connect (OIDC) authentication with external identity providers. Licensed under GPL-2.0.
+
+## Architecture & Key Paths
+
+- `lib/` -- PHP application logic
+- `appinfo/` -- ownCloud app metadata
+- `l10n/` -- Translation files
+- `img/` -- Images
+- `tests/` -- Unit tests
+- `Makefile` -- Build and test automation
+- `composer.json` -- PHP dependencies
+
+## Development Conventions
+
+- PHP code follows ownCloud coding standards
+- Static analysis with PHPStan
+
+## Build & Test Commands
+
+```bash
+make dev                      # Initialize dev environment
+make dist                     # Build distribution package
+make test-php-unit            # Run PHP unit tests
+make test-php-style           # Check PHP code style
+make clean                    # Clean build artifacts
+```
+
+## Important Constraints
+
+- Licensed under GPL-2.0 (copyleft). Apache 2.0 migration planned.
+- Requires a distributed memcache (Redis/Memcached).
+- All contributions require a DCO sign-off.
+
+
+## OSPO Policy Constraints
+
+### GitHub Actions
+- **Only** use actions owned by `owncloud`, created by GitHub (`actions/*`), verified on the GitHub Marketplace, or verified by the ownCloud Maintainers.
+- Pin all actions to their full commit SHA (not tags): `uses: actions/checkout@<SHA> # vX.Y.Z`
+- Never introduce actions from unverified third parties.
+
+### Dependency Management
+- Dependabot is configured for automated dependency updates.
+- Review and merge Dependabot PRs as part of regular maintenance.
+- Do not introduce new dependencies without discussion in an issue first.
+
+### Git Workflow
+- **Rebase policy**: Always rebase; never create merge commits. Use `git pull --rebase` and `git rebase` before pushing.
+- **Signed commits**: All commits **must** be PGP/GPG signed (`git commit -S -s`).
+- **DCO sign-off**: Every commit needs a `Signed-off-by` line (`git commit -s`).
+- **Conventional Commits & Squash Merge**: Use the [Conventional Commits](https://www.conventionalcommits.org/) format where the repository enforces it. Many repos use squash merge, where the PR title becomes the commit message on the default branch — apply Conventional Commits format to PR titles as well. A reusable GitHub Actions workflow enforces this.
+
+## Context for AI Agents
+
+This app integrates with external OIDC providers for single sign-on. Configuration can be stored in `config.php` or in the `oc_appconfig` database table. Database configuration is preferred for clustered setups. The app supports multiple OIDC providers.


### PR DESCRIPTION
## Summary

This PR is part of the **Kiteworks OSPO community health rollout** ([kiteworks.com/opensource](https://kiteworks.com/opensource)), applied to all ~110 public ownCloud repositories starting May 5, 2026.

- **README.md**: Rewritten with v2 OSPO template
  * License-specific OSPO section with Apache 2.0 migration guidance
  * Mandatory Community & Support section: GitHub Discussions, Matrix, docs, enterprise support, OSPO home
  * Contributing workflow: Rebase Early/Often, Dependabot, PGP/GPG-signed commits, DCO sign-off, GitHub Actions policy
  * Security section pointing to security.owncloud.com + YesWeHack bug bounty
  * Translations link to Transifex ([owncloud project](https://explore.transifex.com/owncloud-org/owncloud/))
- **agents.md** *(new)*: AI agent context file with architecture, build commands, OSPO policy constraints
- **CODE_OF_CONDUCT.md** *(new)*: Redirect to <https://owncloud.com/contribute/code-of-conduct/>
- **CONTRIBUTING.md** *(new)*: Redirect to <https://owncloud.com/contribute/>
- **SECURITY.md** *(new)*: Redirect to <https://security.owncloud.com> + YesWeHack
- **SUPPORT.md** *(new)*: Redirect to <https://owncloud.com/contact-us/> and support channels

## Test plan

- [ ] README renders correctly on GitHub (badges, sections, links)
- [ ] All health file links resolve (CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, SUPPORT)
- [ ] agents.md loads correctly in Claude Code and GitHub Copilot
- [ ] License referenced in README matches actual LICENSE file in repo

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) as part of the ownCloud OSPO rollout.
Kiteworks OSPO: <https://kiteworks.com/opensource>