### PR TITLE
fix: verify token audience to prevent cross-client account takeover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased] - XXXX-XX-XX
 
+### Fixed
+
+- [#356](https://github.com/owncloud/openidconnect/pull/356) - fix: verify token audience to prevent cross-client account takeover
+
 ## [2.3.3] - 2026-04-07
 
 ### Changed

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -169,6 +169,7 @@ class Client extends OpenIDConnectClient {
 				$this->logger->error('Token cannot be verified: ' . $token);
 				throw new OpenIDConnectClientException('Token cannot be verified.');
 			}
+			$this->verifyAudience($payload, $config['client-id'] ?? $this->getClientID());
 			$this->logger->debug('Access token payload: ' . \json_encode($payload, JSON_THROW_ON_ERROR));
 			/* @phan-suppress-next-line PhanTypeExpectedObjectPropAccess */
 			return $payload->exp;
@@ -200,6 +201,26 @@ class Client extends OpenIDConnectClient {
 			throw new OpenIDConnectClientException('Token (as per introspection) is inactive');
 		}
 		return $introData->exp;
+	}
+
+	/**
+	 * Ensures the token was issued for this relying party by asserting that the
+	 * configured client-id is present in the token's "aud" (audience) claim.
+	 * Without this check a correctly signed token minted by the same issuer for
+	 * a different client would be accepted (see OC10-115). The "aud" claim may
+	 * be a single string or an array of strings per RFC 7519.
+	 *
+	 * @param object $payload the decoded access token payload
+	 * @param string|null $clientId the configured relying party client-id
+	 * @throws OpenIDConnectClientException if the audience does not match
+	 */
+	private function verifyAudience(object $payload, ?string $clientId): void {
+		$audience = $payload->aud ?? null;
+		$audiences = \is_array($audience) ? $audience : [$audience];
+		if ($clientId === null || !\in_array($clientId, $audiences, true)) {
+			$this->logger->error('Token audience does not match the configured client-id: ' . \json_encode($audience));
+			throw new OpenIDConnectClientException('Token audience does not match the configured client-id');
+		}
 	}
 
 	public function introspectToken($token, $token_type_hint = '', $clientId = null, $clientSecret = null) {

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -236,4 +236,58 @@ class ClientTest extends TestCase {
 			'preferred_username' => 'alice@example.net'
 		], $info);
 	}
+
+	public function providesAudienceData(): array {
+		return [
+			'aud string matches client-id' => ['owncloud-client', true],
+			'aud array contains client-id' => [['owncloud-client', 'client-a'], true],
+			'aud string is another client' => ['client-a', false],
+			'aud array without client-id' => [['client-a', 'client-b'], false],
+			'aud missing' => [null, false],
+		];
+	}
+
+	/**
+	 * @dataProvider providesAudienceData
+	 * @param string|array|null $aud
+	 * @param bool $expectValid
+	 * @throws JsonException
+	 * @throws OpenIDConnectClientException
+	 */
+	public function testVerifyTokenAudience($aud, bool $expectValid): void {
+		$this->config->method('getSystemValue')->willReturnCallback(static function ($key) {
+			if ($key === 'openid-connect') {
+				return [
+					'provider-url' => 'https://example.net',
+					'client-id' => 'owncloud-client',
+					'client-secret' => 'secret',
+				];
+			}
+			return null;
+		});
+
+		$payload = ['exp' => \time() + 3600];
+		if ($aud !== null) {
+			$payload['aud'] = $aud;
+		}
+
+		$this->client = $this->getMockBuilder(Client::class)
+			->setConstructorArgs([$this->config, $this->urlGenerator, $this->session, $this->logger, $this->clientService])
+			->onlyMethods(['getAccessTokenPayload', 'verifyJWTsignature', 'setAccessToken'])
+			->getMock();
+		$this->client->method('setAccessToken');
+		$this->client->method('getAccessTokenPayload')->willReturn((object)$payload);
+		$this->client->method('verifyJWTsignature')->willReturn(true);
+
+		if (!$expectValid) {
+			$this->expectException(OpenIDConnectClientException::class);
+			$this->expectExceptionMessage('Token audience does not match the configured client-id');
+		}
+
+		$exp = $this->client->verifyToken('some-token');
+
+		if ($expectValid) {
+			self::assertEquals($payload['exp'], $exp);
+		}
+	}
 }

--- a/tests/unit/OpenIdConnectAuthModuleTest.php
+++ b/tests/unit/OpenIdConnectAuthModuleTest.php
@@ -183,9 +183,9 @@ class OpenIdConnectAuthModuleTest extends TestCase {
 	 * @throws LoginException
 	 */
 	public function testValidTokenWithJWT(): void {
-		$this->client->method('getOpenIdConfig')->willReturn([]);
+		$this->client->method('getOpenIdConfig')->willReturn(['client-id' => 'client-id']);
 		$this->client->method('verifyJWTsignature')->willReturn(true);
-		$this->client->method('getAccessTokenPayload')->willReturn((object)['exp' => \time() + 3600]);
+		$this->client->method('getAccessTokenPayload')->willReturn((object)['exp' => \time() + 3600, 'aud' => 'client-id']);
 		$this->client->method('getUserInfo')->willReturn((object)['email' => 'foo@example.com']);
 		$this->cacheFactory->method('create')->willReturn(new ArrayCache());
 		$user = $this->createMock(IUser::class);
@@ -217,12 +217,12 @@ class OpenIdConnectAuthModuleTest extends TestCase {
 	 */
 	public function testValidTokenWithAutoUpdate(): void {
 		$userInfo = (object)['email' => 'foo@example.com'];
-		$openIdConfig = ['auto-provision' => [ 'update' => ['enabled' => true ]]];
+		$openIdConfig = ['client-id' => 'client-id', 'auto-provision' => [ 'update' => ['enabled' => true ]]];
 		$this->client->method('getOpenIdConfig')->willReturn($openIdConfig);
 		$this->client->method('getAutoProvisionConfig')->willReturn($openIdConfig['auto-provision']);
 		$this->client->method('getUserInfo')->willReturn($userInfo);
 		$this->client->method('verifyJWTsignature')->willReturn(true);
-		$this->client->method('getAccessTokenPayload')->willReturn((object)['exp' => time() + 100]);
+		$this->client->method('getAccessTokenPayload')->willReturn((object)['exp' => time() + 100, 'aud' => 'client-id']);
 		$this->autoProvisioningService->method('autoUpdateEnabled')->willReturn(true);
 		$this->cacheFactory->method('create')->willReturn(new ArrayCache());
 

--- a/tests/unit/SessionVerifierTest.php
+++ b/tests/unit/SessionVerifierTest.php
@@ -211,8 +211,9 @@ class SessionVerifierTest extends TestCase {
 		$cache = $this->createMock(ICache::class);
 		$this->cacheFactory->expects(self::exactly(2))->method('create')->with('oca.openid-connect')->willReturn($cache);
 		$exp = \time() + 3600;
+		$this->client->method('getOpenIdConfig')->willReturn(['client-id' => 'client-id']);
 		$this->client->method('verifyJWTsignature')->willReturn(true);
-		$this->client->method('getAccessTokenPayload')->willReturn((object)['exp' => $exp]);
+		$this->client->method('getAccessTokenPayload')->willReturn((object)['exp' => $exp, 'aud' => 'client-id']);
 
 		$cache->expects(self::once())->method('set')->with('access-123456', $exp);
 		$this->userSession->expects(self::never())->method('logout');


### PR DESCRIPTION
## Summary

The OpenID Connect access-token verifier checked the JWT **signature** and **expiry** but never validated the **`aud` (audience)** claim. A correctly signed, unexpired token minted by the same issuer for a *different* client was therefore accepted. An attacker holding such a token (e.g. issued for another app on a shared IdP) could authenticate as the matching ownCloud account via API/WebDAV bearer auth or the browser session — leading to account takeover.

Ref: OC10-115 (bug bounty, YWH-805355).

## Fix

`Client::verifyToken()` now asserts that the configured `client-id` is present in the token's audience before accepting it:

- Handles `aud` as a single string or an array of strings (per RFC 7519).
- Rejects the token with `OpenIDConnectClientException` when the configured client-id is absent (or when `aud`/client-id is missing).

Both entry points — the bearer auth module (`OpenIdConnectAuthModule::authToken`) and the browser session (`SessionVerifier::verifySession`) — funnel through `verifyToken`, so both paths are covered by this single change.

## Tests

- New `ClientTest::testVerifyTokenAudience` covering: `aud` string match, `aud` array containing client-id, wrong `aud` string, `aud` array without client-id, and missing `aud`.
- Updated three existing "valid token" fixtures (`OpenIdConnectAuthModuleTest`, `SessionVerifierTest`) to carry a matching audience, reflecting what a legitimate token must contain.
- Full unit suite green: **118 tests, 200 assertions**. `php-cs-fixer` (ownCloud coding standard) reports no issues.

## Upgrade note

This enforces audience validation strictly, with no opt-out flag. Deployments that currently rely on accepting tokens minted for a *different* client on the same IdP will stop working after this change — which is the intended security behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)